### PR TITLE
Remove unnecessary characters

### DIFF
--- a/trailsense-edge/src/probe_parser.rs
+++ b/trailsense-edge/src/probe_parser.rs
@@ -35,4 +35,3 @@ pub fn fingerprint_probe(data: &[u8]) -> u16 {
 
     fingerprint
 }
-∂


### PR DESCRIPTION
This pull request makes a minor change to the `trailsense-edge/src/probe_parser.rs` file by removing an extraneous character at the end of the `fingerprint_probe` function.
