### PR TITLE
Implement survivor-based fingerprint deduplication for people counting

### DIFF
--- a/trailsense-edge/.cargo/config.toml
+++ b/trailsense-edge/.cargo/config.toml
@@ -4,7 +4,7 @@ runner = "espflash flash --monitor --monitor-baud 115200 --chip esp32"
 [env]
 ESP_LOG="info"
 TRAILSENSE_API_URL = "https://api.trailsense.daugt.com/ingest/"
-TRAILSENSE_EDGE_ID = "1"
+TRAILSENSE_EDGE_ID = "71ec4873-944e-49c1-b7c4-4b856797715f"
 
 [build]
 rustflags = [

--- a/trailsense-edge/Cargo.lock
+++ b/trailsense-edge/Cargo.lock
@@ -2254,6 +2254,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_json"
+version = "1.0.149"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+dependencies = [
+ "itoa",
+ "memchr",
+ "serde",
+ "serde_core",
+ "zmij",
+]
+
+[[package]]
 name = "serde_yaml"
 version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2529,6 +2542,8 @@ dependencies = [
  "ieee80211",
  "log",
  "reqwless",
+ "serde",
+ "serde_json",
  "smoltcp",
  "static_cell",
 ]
@@ -2735,3 +2750,9 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zmij"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"

--- a/trailsense-edge/Cargo.toml
+++ b/trailsense-edge/Cargo.toml
@@ -71,7 +71,8 @@ reqwless = { version ="0.14.0", default-features=false, features = [
 ]}
 embassy-sync = "0.7.2"
 heapless = "0.9.2"
-
+serde_json = { version = "1.0.149", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.228", default-features = false, features = ["derive", "alloc"] }
 
 [profile.dev]
 # Rust debug is too slow.

--- a/trailsense-edge/src/bin/main.rs
+++ b/trailsense-edge/src/bin/main.rs
@@ -19,7 +19,7 @@ use esp_hal::timer::timg::TimerGroup;
 use log::info;
 use static_cell::StaticCell;
 use trailsense_edge::{
-    probe_parser::read_packet,
+    probes::probe_parser::read_packet,
     wifi::{self, manager::WifiCmd},
 };
 

--- a/trailsense-edge/src/lib.rs
+++ b/trailsense-edge/src/lib.rs
@@ -1,5 +1,6 @@
 #![no_std]
 
 pub mod models;
-pub mod probe_parser;
+pub mod packages;
+pub mod probes;
 pub mod wifi;

--- a/trailsense-edge/src/packages/mod.rs
+++ b/trailsense-edge/src/packages/mod.rs
@@ -1,0 +1,1 @@
+pub mod package_store;

--- a/trailsense-edge/src/packages/package_store.rs
+++ b/trailsense-edge/src/packages/package_store.rs
@@ -1,0 +1,48 @@
+extern crate alloc;
+use alloc::vec::Vec;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+use embassy_time::Instant;
+
+#[derive(Debug, Clone)]
+pub struct PackageEntity {
+    pub count: u32,
+    pub age_in_seconds: u64,
+    pub last_seen: Instant,
+}
+
+impl PackageEntity {
+    pub fn new(count: u32) -> Self {
+        Self {
+            count,
+            age_in_seconds: 0,
+            last_seen: Instant::now(),
+        }
+    }
+
+    pub fn update_age(&mut self) {
+        let now = Instant::now();
+        let delta = now.duration_since(self.last_seen);
+        self.age_in_seconds = self.age_in_seconds.saturating_add(delta.as_secs());
+        self.last_seen = now;
+    }
+}
+
+static PACKAGES: Mutex<CriticalSectionRawMutex, Vec<PackageEntity>> = Mutex::new(Vec::new());
+
+pub async fn push(count: u32) {
+    let mut guard = PACKAGES.lock().await;
+    guard.push(PackageEntity::new(count));
+}
+
+pub async fn snapshot_with_age() -> Vec<PackageEntity> {
+    let mut guard = PACKAGES.lock().await;
+    for p in guard.iter_mut() {
+        p.update_age();
+    }
+    guard.clone()
+}
+
+pub async fn drain() {
+    let mut guard = PACKAGES.lock().await;
+    guard.clear();
+}

--- a/trailsense-edge/src/probes/counter.rs
+++ b/trailsense-edge/src/probes/counter.rs
@@ -1,0 +1,29 @@
+extern crate alloc;
+use alloc::vec::Vec;
+
+pub fn deduplicate_probes(input_fingerprints: &[u16]) -> u32 {
+    if input_fingerprints.is_empty() {
+        return 0;
+    }
+
+    let mut survivors: Vec<u16> = Vec::new();
+    survivors.push(input_fingerprints[0]);
+
+    for &fingerprint in &input_fingerprints[1..] {
+        if !is_duplicate(2, fingerprint, &survivors) {
+            survivors.push(fingerprint);
+        }
+    }
+
+    survivors.len() as u32
+}
+
+fn is_duplicate(threshold: u32, input: u16, survivors: &[u16]) -> bool {
+    for &s in survivors {
+        let dist = (input ^ s).count_ones(); // Hamming distance
+        if dist <= threshold {
+            return true;
+        }
+    }
+    false
+}

--- a/trailsense-edge/src/probes/fingerprint_store.rs
+++ b/trailsense-edge/src/probes/fingerprint_store.rs
@@ -2,12 +2,15 @@ extern crate alloc;
 use alloc::vec::Vec;
 use core::cell::RefCell;
 use embassy_sync::blocking_mutex::{Mutex, raw::CriticalSectionRawMutex};
+use heapless::Vec as HeaplessVec;
 
-static FINGERPRINTS: Mutex<CriticalSectionRawMutex, RefCell<Vec<u16>>> =
-    Mutex::new(RefCell::new(Vec::new()));
+const MAX_FINGERPRINTS: usize = 2048;
 
-pub fn push(fingerprint: u16) {
-    FINGERPRINTS.lock(|v| v.borrow_mut().push(fingerprint));
+static FINGERPRINTS: Mutex<CriticalSectionRawMutex, RefCell<HeaplessVec<u16, MAX_FINGERPRINTS>>> =
+    Mutex::new(RefCell::new(HeaplessVec::new()));
+
+pub fn push(fingerprint: u16) -> bool {
+    FINGERPRINTS.lock(|v| v.borrow_mut().push(fingerprint).is_ok())
 }
 
 pub fn drain() {
@@ -15,5 +18,5 @@ pub fn drain() {
 }
 
 pub fn snapshot() -> Vec<u16> {
-    FINGERPRINTS.lock(|v| v.borrow().clone())
+    FINGERPRINTS.lock(|v| v.borrow().iter().copied().collect())
 }

--- a/trailsense-edge/src/probes/fingerprint_store.rs
+++ b/trailsense-edge/src/probes/fingerprint_store.rs
@@ -1,0 +1,19 @@
+extern crate alloc;
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use embassy_sync::blocking_mutex::{Mutex, raw::CriticalSectionRawMutex};
+
+static FINGERPRINTS: Mutex<CriticalSectionRawMutex, RefCell<Vec<u16>>> =
+    Mutex::new(RefCell::new(Vec::new()));
+
+pub fn push(fingerprint: u16) {
+    FINGERPRINTS.lock(|v| v.borrow_mut().push(fingerprint));
+}
+
+pub fn drain() {
+    FINGERPRINTS.lock(|v| v.borrow_mut().clear());
+}
+
+pub fn snapshot() -> Vec<u16> {
+    FINGERPRINTS.lock(|v| v.borrow().clone())
+}

--- a/trailsense-edge/src/probes/mod.rs
+++ b/trailsense-edge/src/probes/mod.rs
@@ -1,0 +1,3 @@
+pub mod counter;
+pub mod fingerprint_store;
+pub mod probe_parser;

--- a/trailsense-edge/src/probes/probe_parser.rs
+++ b/trailsense-edge/src/probes/probe_parser.rs
@@ -6,7 +6,7 @@ use ieee80211::{
 };
 use log::info;
 
-use crate::models::MODEL;
+use crate::{models::MODEL, probes::fingerprint_store};
 
 /// # Fingerprint Probe
 ///
@@ -50,7 +50,6 @@ fn fingerprint_probe(data: &[u8]) -> u16 {
             score -= negative_bits.count_ones() as i32;
         }
 
-        log::info!("Filter {} resulted in {}", idx, score);
         let bit = if score >= model.threshold as i32 {
             1
         } else {
@@ -58,11 +57,11 @@ fn fingerprint_probe(data: &[u8]) -> u16 {
         };
         fingerprint = (fingerprint << 1) | bit;
     }
-
+    fingerprint_store::push(fingerprint);
     fingerprint
 }
 
-pub fn read_packet(packet: PromiscuousPkt) {
+pub fn read_packet(packet: PromiscuousPkt<'_>) {
     let Ok(frame) = GenericFrame::new(&packet.data, false) else {
         return;
     };
@@ -79,15 +78,7 @@ pub fn read_packet(packet: PromiscuousPkt) {
                         return;
                     }
                     let body = &packet.data[body_offset..];
-
                     let fingerprint = fingerprint_probe(body);
-
-                    info!(
-                        "Source MAC: {:02x}:{:02x}:{:02x}:{:02x}:{:02x}:{:02x}",
-                        source[0], source[1], source[2], source[3], source[4], source[5]
-                    );
-                    info!("Probe body[0..16]: {:02x?}", &body[0..body.len().min(16)]);
-
                     info!("Fingerprint: {:08b}", fingerprint);
                 }
             }

--- a/trailsense-edge/src/probes/probe_parser.rs
+++ b/trailsense-edge/src/probes/probe_parser.rs
@@ -4,7 +4,7 @@ use ieee80211::{
     GenericFrame,
     common::{FrameType, ManagementFrameSubtype},
 };
-use log::info;
+use log::warn;
 
 use crate::{models::MODEL, probes::fingerprint_store};
 
@@ -57,7 +57,9 @@ fn fingerprint_probe(data: &[u8]) -> u16 {
         };
         fingerprint = (fingerprint << 1) | bit;
     }
-    fingerprint_store::push(fingerprint);
+    if !fingerprint_store::push(fingerprint) {
+        warn!("Fingerprint overflow!");
+    }
     fingerprint
 }
 
@@ -78,8 +80,7 @@ pub fn read_packet(packet: PromiscuousPkt<'_>) {
                         return;
                     }
                     let body = &packet.data[body_offset..];
-                    let fingerprint = fingerprint_probe(body);
-                    info!("Fingerprint: {:08b}", fingerprint);
+                    fingerprint_probe(body);
                 }
             }
         }

--- a/trailsense-edge/src/wifi/http.rs
+++ b/trailsense-edge/src/wifi/http.rs
@@ -1,3 +1,7 @@
+extern crate alloc;
+use alloc::vec::Vec;
+
+use alloc::string::String;
 use embassy_net::{
     Stack,
     dns::DnsSocket,
@@ -9,6 +13,8 @@ use reqwless::{
     request::RequestBuilder,
 };
 
+use crate::packages::package_store::PackageEntity;
+
 const BASE_URL: &str = match option_env!("TRAILSENSE_BASE_URL") {
     Some(v) => v,
     None => "https://api.trailsense.daugt.com",
@@ -16,16 +22,16 @@ const BASE_URL: &str = match option_env!("TRAILSENSE_BASE_URL") {
 
 const DEVICE_ID: &str = match option_env!("TRAILSENSE_EDGE_ID") {
     Some(v) => v,
-    None => "1",
+    None => "71ec4873-944e-49c1-b7c4-4b856797715f",
 };
 
-pub async fn send_data(stack: Stack<'_>, tls_seed: u64) {
+pub async fn send_data(stack: Stack<'_>, tls_seed: u64, packages: Vec<PackageEntity>) -> bool {
     let mut rx_buffer = [0; 4096]; // TODO: Refactor to reuse static TLS RX/TX buffers instead of allocating new ones per call, to reduce memory usage on constrained devices.
     let mut tx_buffer = [0; 4096];
 
     let mut url = heapless::String::<128>::new();
     use core::fmt::Write;
-    write!(&mut url, "{}/ingest/{}", BASE_URL, DEVICE_ID).unwrap();
+    write!(&mut url, "{}/ingest", BASE_URL).unwrap();
 
     let dns = DnsSocket::new(stack);
     let tcp_state = TcpClientState::<1, 4096, 4096>::new();
@@ -41,12 +47,28 @@ pub async fn send_data(stack: Stack<'_>, tls_seed: u64) {
     let mut client = HttpClient::new_with_tls(&tcp, &dns, tls);
 
     let mut buffer = [0u8; 4096];
+
+    let mut body = String::new();
+    body.push('[');
+    for (i, p) in packages.iter().enumerate() {
+        if i > 0 {
+            body.push(',');
+        }
+        write!(
+            &mut body,
+            "{{\"age_in_seconds\":{},\"count\":{},\"node_id\":\"{}\"}}",
+            p.age_in_seconds, p.count, DEVICE_ID
+        )
+        .unwrap();
+    }
+    body.push(']');
+
     let mut http_req = client
         .request(reqwless::request::Method::POST, url.as_str())
         .await
         .unwrap()
         .content_type(reqwless::headers::ContentType::ApplicationJson)
-        .body(br#"{"wifi":200,"bluetooth":10}"#.as_slice());
+        .body(body.as_bytes());
 
     let response = http_req.send(&mut buffer).await.unwrap();
     let status = response.status;
@@ -54,12 +76,14 @@ pub async fn send_data(stack: Stack<'_>, tls_seed: u64) {
 
     let Ok(body_content) = core::str::from_utf8(body) else {
         error!("Something went wrong when parsing the content");
-        return;
+        return false;
     };
 
     if status.is_successful() {
         info!("Success ({:?}): {}", status, body_content);
+        return true;
     } else {
         error!("Error ({:?}): {}", status, body_content);
+        return false;
     }
 }

--- a/trailsense-edge/src/wifi/http.rs
+++ b/trailsense-edge/src/wifi/http.rs
@@ -51,6 +51,11 @@ pub async fn send_data(stack: Stack<'_>, tls_seed: u64, packages: Vec<PackageEnt
     let mut body = String::new();
     body.push('[');
     for (i, p) in packages.iter().enumerate() {
+        info!(
+            "Node ID: {}, Count: {}, Age in Seconds: {}",
+            DEVICE_ID, p.count, p.age_in_seconds
+        );
+
         if i > 0 {
             body.push(',');
         }

--- a/trailsense-edge/src/wifi/uploader.rs
+++ b/trailsense-edge/src/wifi/uploader.rs
@@ -35,8 +35,8 @@ pub async fn uploader_task(
 
         let fingerprint_snapshot = fingerprint_store::snapshot();
         let curr_count = counter::deduplicate_probes(&fingerprint_snapshot);
-
-        package_store::push(curr_count).await;
+        package_store::push(curr_count).await; // TODO: implement limit to avoid buffer overflow of http request. Basically use chunking.
+        fingerprint_store::drain();
 
         wifi_command_sender.send(WifiCmd::StopSniffing).await;
 

--- a/trailsense-edge/src/wifi/uploader.rs
+++ b/trailsense-edge/src/wifi/uploader.rs
@@ -35,7 +35,6 @@ pub async fn uploader_task(
 
         let fingerprint_snapshot = fingerprint_store::snapshot();
         let curr_count = counter::deduplicate_probes(&fingerprint_snapshot);
-        info!("Current count of people : {}", curr_count);
 
         package_store::push(curr_count).await;
 


### PR DESCRIPTION
 ## Summary
Implemented a fingerprint de-duplication algorithm and now sends people counts to the backend with `age_in_seconds`.

## Changes

### Main changes
- Added fingerprint de-duplication using Hamming distance (based on the paper).
- Added temporary storage for fingerprints and packages.

### Additional fixes
- Improved logging.

### Fingerprint de-duplication
- Uses XOR to compare two fingerprints.
- Applies a difference threshold to classify matches:
  - If the difference is **below** the threshold, fingerprints are treated as the **same device**.
  - If the difference is **above** the threshold, fingerprints are treated as **different devices**.
- Uses a survivor-based method to apply de-duplication over time.

### Relative age of packages
- Packages are sent with their age in seconds, computed immediately before sending.
- If a package is delayed due to an error, it is retried later with an updated age.