### PR TITLE
14 keep wi fi mode switching inside manager

### DIFF
--- a/trailsense-edge/Cargo.lock
+++ b/trailsense-edge/Cargo.lock
@@ -54,9 +54,9 @@ checksum = "c583acf993cf4245c4acb0a2cc2ab1f9cc097de73411bb6d3647ff6af2b1013d"
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "as-slice"
@@ -117,7 +117,7 @@ checksum = "f48d6ace212fdf1b45fd6b566bb40808415344642b76c3224c07c8df9da81e97"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -128,7 +128,7 @@ checksum = "d3ca019570363e800b05ad4fd890734f28ac7b72f563ad8a35079efb793616f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -139,9 +139,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
 name = "bleps"
@@ -168,7 +168,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -204,9 +204,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytemuck"
@@ -338,7 +338,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -382,7 +382,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -395,7 +395,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -408,7 +408,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -419,7 +419,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -430,7 +430,7 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -441,7 +441,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -479,7 +479,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -499,7 +499,7 @@ checksum = "780eb241654bf097afb00fc5f054a09b687dad862e485fdcf8399bb056565370"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -514,31 +514,32 @@ dependencies = [
 
 [[package]]
 name = "der"
-version = "0.8.0-rc.10"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c1d73e9668ea6b6a28172aa55f3ebec38507131ce179051c8033b5c6037653"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
 dependencies = [
  "const-oid 0.10.2",
  "der_derive",
+ "heapless 0.9.2",
  "time",
 ]
 
 [[package]]
 name = "der_derive"
-version = "0.8.0-rc.6"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be645fee2afe89d293b96c19e4456e6ac69520fc9c6b8a58298550138e361ffe"
+checksum = "59600e2c2d636fde9b65e99cc6445ac770c63d3628195ff39932b8d6d7409903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -655,7 +656,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -871,7 +872,7 @@ checksum = "09d1e46155b61b5b5cc486e01dacc55a623689bded89835965b15436734f078a"
 dependencies = [
  "aes-gcm",
  "const-oid 0.10.2",
- "der 0.8.0-rc.10",
+ "der 0.8.0",
  "digest",
  "ecdsa",
  "ed25519-dalek",
@@ -909,7 +910,7 @@ dependencies = [
  "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -989,7 +990,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54786287c0a61ca0f78cb0c338a39427551d1be229103b4444591796c579e093"
 dependencies = [
  "bitfield 0.19.4",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "bytemuck",
  "cfg-if",
  "critical-section",
@@ -1047,7 +1048,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "termcolor",
 ]
 
@@ -1310,9 +1311,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1324,9 +1325,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1334,39 +1335,38 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
  "futures-sink",
  "futures-task",
  "pin-project-lite",
- "pin-utils",
 ]
 
 [[package]]
@@ -1585,7 +1585,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1596,9 +1596,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.18"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e67e8da4c49d6d9909fe03361f9b620f58898859f5c7aded68351e85e71ecf50"
+checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
 dependencies = [
  "jiff-static",
  "log",
@@ -1609,20 +1609,20 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.18"
+version = "0.2.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c84ee7f197eca9a86c6fd6cb771e55eb991632f15f2bc3ca6ec838929e6e78"
+checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -1630,9 +1630,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.180"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "linked_list_allocator"
@@ -1699,9 +1699,9 @@ checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "nb"
@@ -1726,7 +1726,7 @@ checksum = "f967505aabc8af5752d098c34146544a43684817cdba8f9725b292530cabbf53"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1771,7 +1771,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1867,15 +1867,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
-
-[[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkcs8"
@@ -1932,7 +1926,7 @@ checksum = "a33fa6ec7f2047f572d49317cca19c87195de99c6e5b6ee492da701cfe02b053"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1961,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.4.0"
+version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
  "toml_edit",
 ]
@@ -2011,7 +2005,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2025,9 +2019,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -2107,7 +2101,7 @@ checksum = "7d323d13972c1b104aa036bc692cd08b822c8bbf23d79a27c526095856499799"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2136,7 +2130,7 @@ checksum = "def519ddeeb5e43c2b4fc3952c27b3a86782fc05192f322b2309125cd85b1fc3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2147,13 +2141,14 @@ checksum = "b1376b15f3ff160e9b1e8ea564ce427f2f6fcf77528cc0a8bf405cb476f9cea7"
 
 [[package]]
 name = "rlsf"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "222fb240c3286247ecdee6fa5341e7cdad0ffdf8e7e401d9937f2d58482a20bf"
+checksum = "1646a59a9734b8b7a0ac51689388a60fe1625d4b956348e9de07591a1478457a"
 dependencies = [
  "cfg-if",
  "const-default",
  "libc",
+ "rustversion",
  "svgbobdoc",
 ]
 
@@ -2174,9 +2169,9 @@ checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "scroll"
@@ -2195,7 +2190,7 @@ checksum = "ed76efe62313ab6610570951494bdaa81568026e0318eaa55f167de70eeea67d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2250,7 +2245,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2388,7 +2383,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2423,9 +2418,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2458,14 +2453,14 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "num-conv",
@@ -2492,18 +2487,18 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.0.0+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "32c2555c699578a4f59f0cc68e5116c8d7cabbd45e1409b989d4be085b53f13e"
 dependencies = [
  "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.4+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "7193cbd0ce53dc966037f54351dbbcf0d5a642c7f0038c382ef9e677ce8c13f2"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2513,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.0.9+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "702d4415e08923e7e1ef96cd5727c0dfed80b4d2fa25db9647fe5eb6f7c5a4c4"
 dependencies = [
  "winnow",
 ]
@@ -2526,7 +2521,9 @@ version = "0.1.0"
 dependencies = [
  "bleps",
  "critical-section",
+ "der 0.8.0",
  "embassy-executor",
+ "embassy-futures",
  "embassy-net",
  "embassy-sync 0.7.2",
  "embassy-time",
@@ -2562,9 +2559,9 @@ checksum = "e87a2ed6b42ec5e28cc3b94c09982969e9227600b2e3dcbc1db927a84c06bd69"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-width"
@@ -2590,9 +2587,9 @@ checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2618,9 +2615,9 @@ checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -2631,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2641,22 +2638,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
 dependencies = [
  "unicode-ident",
 ]
@@ -2687,9 +2684,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -2722,27 +2719,27 @@ checksum = "96fb42cd29c42f8744c74276e9f5bee7b06685bbe5b88df891516d72cb320450"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "a789c6e490b576db9f7e6b6d661bcc9799f7c0ac8352f56ea20193b2681532e5"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "f65c489a7071a749c849713807783f70672b28094011623e200cb86dcb835953"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2753,6 +2750,6 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/trailsense-edge/Cargo.toml
+++ b/trailsense-edge/Cargo.toml
@@ -73,6 +73,8 @@ embassy-sync = "0.7.2"
 heapless = "0.9.2"
 serde_json = { version = "1.0.149", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.228", default-features = false, features = ["derive", "alloc"] }
+der = { version = "0.8.0", features = ["heapless"] }
+embassy-futures = "0.1.2"
 
 [profile.dev]
 # Rust debug is too slow.

--- a/trailsense-edge/src/bin/main.rs
+++ b/trailsense-edge/src/bin/main.rs
@@ -8,7 +8,9 @@
 #![deny(clippy::large_stack_frames)]
 
 use embassy_executor::Spawner;
-use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel};
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex, channel::Channel, pubsub::PubSubChannel,
+};
 use esp_backtrace as _;
 use esp_hal::clock::CpuClock;
 use esp_hal::peripherals::Peripherals;
@@ -20,8 +22,12 @@ use log::{error, info};
 use static_cell::StaticCell;
 use trailsense_edge::{
     network::{self, factory::build_active_transport},
+    orchestration::{
+        orchestrator::orchestrate_node,
+        types::{SystemCmd, SystemEvents},
+    },
     probes::probe_parser::read_packet,
-    wifi::{self, manager::WifiCmd, tasks::WifiControlCmd},
+    wifi::{self, tasks::WifiControlCmd},
 };
 
 extern crate alloc;
@@ -31,8 +37,13 @@ extern crate alloc;
 esp_bootloader_esp_idf::esp_app_desc!();
 
 static RADIO_CELL: StaticCell<esp_radio::Controller<'static>> = StaticCell::new();
-static WIFI_COMMAND_CHANNEL: Channel<CriticalSectionRawMutex, WifiCmd, 4> = Channel::new();
 static WIFI_CONTROL_CHANNEL: Channel<CriticalSectionRawMutex, WifiControlCmd, 4> = Channel::new();
+
+static SNIFFING_COMMAND_CHANNEL: Channel<CriticalSectionRawMutex, SystemCmd, 4> = Channel::new();
+static NETWORK_COMMAND_CHANNEL: Channel<CriticalSectionRawMutex, SystemCmd, 4> = Channel::new();
+static ORCHESTRATOR_EVENT_CHANNEL: PubSubChannel<CriticalSectionRawMutex, SystemEvents, 4, 1, 2> =
+    PubSubChannel::new();
+
 const INIT_RETRY_DELAY: Duration = Duration::from_secs(5);
 const FATAL_SLEEP: Duration = Duration::from_secs(1);
 
@@ -102,17 +113,52 @@ async fn main(spawner: Spawner) -> ! {
     #[cfg(feature = "uplink-wifi")]
     let transport = build_active_transport(ctx, WIFI_CONTROL_CHANNEL.sender());
 
+    let orchestrator_network_publisher = match ORCHESTRATOR_EVENT_CHANNEL.publisher() {
+        Ok(p) => p,
+        Err(e) => {
+            error!("Failed to initialize Wi-Fi controller (fatal): {:?}", e);
+            fatal_idle().await;
+        }
+    };
+
     if let Err(e) = spawner.spawn(network::uploader::uploader_task(
         transport,
-        WIFI_COMMAND_CHANNEL.sender(),
+        NETWORK_COMMAND_CHANNEL.receiver(),
+        orchestrator_network_publisher,
     )) {
         error!("Failed to spawn uploader task: {}", e);
+    }
+
+    let orchestrator_sniffer_publisher = match ORCHESTRATOR_EVENT_CHANNEL.publisher() {
+        Ok(p) => p,
+        Err(e) => {
+            error!("Failed to initialize Wi-Fi controller (fatal): {:?}", e);
+            fatal_idle().await;
+        }
+    };
+
+    let orchestrator_event_subscriber = match ORCHESTRATOR_EVENT_CHANNEL.subscriber() {
+        Ok(p) => p,
+        Err(e) => {
+            error!("Failed to initialize Wi-Fi controller (fatal): {:?}", e);
+            fatal_idle().await;
+        }
+    };
+
+    if let Err(e) = spawner.spawn(orchestrate_node(
+        orchestrator_event_subscriber,
+        NETWORK_COMMAND_CHANNEL.sender(),
+        SNIFFING_COMMAND_CHANNEL.sender(),
+        trailsense_edge::orchestration::types::SystemState::Idle,
+    )) {
+        error!("Failed to spawn wifi manager task: {}", e);
     }
 
     if let Err(e) = spawner.spawn(wifi::manager::wifi_manager_task(
         interfaces.sniffer,
         read_packet,
-        WIFI_COMMAND_CHANNEL.receiver(),
+        SNIFFING_COMMAND_CHANNEL.receiver(),
+        orchestrator_sniffer_publisher,
     )) {
         error!("Failed to spawn wifi manager task: {}", e);
     }

--- a/trailsense-edge/src/bin/main.rs
+++ b/trailsense-edge/src/bin/main.rs
@@ -41,7 +41,7 @@ static WIFI_CONTROL_CHANNEL: Channel<CriticalSectionRawMutex, WifiControlCmd, 4>
 
 static SNIFFING_COMMAND_CHANNEL: Channel<CriticalSectionRawMutex, SystemCmd, 4> = Channel::new();
 static NETWORK_COMMAND_CHANNEL: Channel<CriticalSectionRawMutex, SystemCmd, 4> = Channel::new();
-static ORCHESTRATOR_EVENT_CHANNEL: PubSubChannel<CriticalSectionRawMutex, SystemEvents, 4, 1, 2> =
+static ORCHESTRATOR_EVENT_CHANNEL: PubSubChannel<CriticalSectionRawMutex, SystemEvents, 4, 1, 3> =
     PubSubChannel::new();
 
 const INIT_RETRY_DELAY: Duration = Duration::from_secs(5);
@@ -97,9 +97,22 @@ async fn main(spawner: Spawner) -> ! {
     let mut rng = Rng::new();
     let (ctx, runner) = wifi::init_stack(&mut rng, interfaces.sta);
 
+    let orchestrator_transport_publisher = match ORCHESTRATOR_EVENT_CHANNEL.publisher() {
+        Ok(p) => p,
+        Err(e) => {
+            error!(
+                "Failed to get publisher for ORCHESTRATOR_EVENT_CHANNEL (fatal): {:?}",
+                e
+            );
+
+            fatal_idle().await;
+        }
+    };
+
     if let Err(e) = spawner.spawn(wifi::tasks::connect(
         wifi_controller,
         WIFI_CONTROL_CHANNEL.receiver(),
+        orchestrator_transport_publisher,
     )) {
         error!("Failed to spawn connection task: {}", e);
     }
@@ -116,7 +129,11 @@ async fn main(spawner: Spawner) -> ! {
     let orchestrator_network_publisher = match ORCHESTRATOR_EVENT_CHANNEL.publisher() {
         Ok(p) => p,
         Err(e) => {
-            error!("Failed to initialize Wi-Fi controller (fatal): {:?}", e);
+            error!(
+                "Failed to acquire publisher for ORCHESTRATOR_EVENT_CHANNEL (fatal): {:?}",
+                e
+            );
+
             fatal_idle().await;
         }
     };

--- a/trailsense-edge/src/lib.rs
+++ b/trailsense-edge/src/lib.rs
@@ -1,6 +1,7 @@
 #![no_std]
 
 pub mod network;
+pub mod orchestration;
 pub mod packages;
 pub mod probes;
 pub mod wifi;

--- a/trailsense-edge/src/network/active_transport.rs
+++ b/trailsense-edge/src/network/active_transport.rs
@@ -29,4 +29,10 @@ impl UplinkTransport for ActiveTransport {
             ActiveTransport::Wifi(t) => t.send_data(packages).await,
         }
     }
+
+    async fn control(&mut self, cmd: super::TransportControl) {
+        match self {
+            ActiveTransport::Wifi(t) => t.control(cmd).await,
+        }
+    }
 }

--- a/trailsense-edge/src/network/active_transport.rs
+++ b/trailsense-edge/src/network/active_transport.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 use alloc::vec::Vec;
 
 #[cfg(feature = "uplink-wifi")]
-use crate::network::wifi::transport::WifiTransport;
+use crate::{network::wifi::transport::WifiTransport, orchestration::types::CorrelationId};
 use crate::{
     network::{
         UplinkTransport,
@@ -30,9 +30,9 @@ impl UplinkTransport for ActiveTransport {
         }
     }
 
-    async fn control(&mut self, cmd: super::TransportControl) {
+    async fn control(&mut self, cmd: super::TransportControl, id: CorrelationId) {
         match self {
-            ActiveTransport::Wifi(t) => t.control(cmd).await,
+            ActiveTransport::Wifi(t) => t.control(cmd, id).await,
         }
     }
 }

--- a/trailsense-edge/src/network/mod.rs
+++ b/trailsense-edge/src/network/mod.rs
@@ -1,6 +1,7 @@
 extern crate alloc;
 use crate::{
     network::types::{ConnectionOutcome, SendDataOutcome},
+    orchestration::types::CorrelationId,
     packages::package_store::PackageEntity,
 };
 use alloc::vec::Vec;
@@ -19,5 +20,5 @@ pub enum TransportControl {
 pub trait UplinkTransport {
     async fn send_data(&mut self, packages: Vec<PackageEntity>) -> SendDataOutcome;
     async fn ensure_connected(&mut self) -> ConnectionOutcome;
-    async fn control(&mut self, cmd: TransportControl);
+    async fn control(&mut self, cmd: TransportControl, id: CorrelationId);
 }

--- a/trailsense-edge/src/network/mod.rs
+++ b/trailsense-edge/src/network/mod.rs
@@ -10,8 +10,14 @@ pub mod types;
 pub mod uploader;
 pub mod wifi;
 
+pub enum TransportControl {
+    Enable,
+    Disable,
+}
+
 #[allow(async_fn_in_trait)]
 pub trait UplinkTransport {
     async fn send_data(&mut self, packages: Vec<PackageEntity>) -> SendDataOutcome;
     async fn ensure_connected(&mut self) -> ConnectionOutcome;
+    async fn control(&mut self, cmd: TransportControl);
 }

--- a/trailsense-edge/src/network/uploader.rs
+++ b/trailsense-edge/src/network/uploader.rs
@@ -16,7 +16,7 @@ pub async fn uploader_task(
     mut transport: ActiveTransport,
     wifi_command_sender: Sender<'static, CriticalSectionRawMutex, WifiCmd, 4>,
 ) {
-    const PERIOD: Duration = Duration::from_secs(20);
+    const PERIOD: Duration = Duration::from_secs(180); // Change for testing reasons.
     const SEND_TIMEOUT: Duration = Duration::from_secs(30);
     const RETRY_DELAY: Duration = Duration::from_millis(500);
     const RADIO_SETTLE_DELAY: Duration = Duration::from_secs(5);

--- a/trailsense-edge/src/network/uploader.rs
+++ b/trailsense-edge/src/network/uploader.rs
@@ -1,6 +1,12 @@
 extern crate alloc;
-use crate::network::{UplinkTransport, types::ConnectionOutcome};
-use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Sender};
+
+use crate::{
+    network::{UplinkTransport, types::ConnectionOutcome},
+    orchestration::types::{SystemCmd, SystemEvents, UploadEvents},
+};
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex, channel::Receiver, pubsub::Publisher,
+};
 use embassy_time::{Duration, Timer, WithTimeout};
 use log::{error, info};
 
@@ -8,85 +14,98 @@ use crate::{
     network::{active_transport::ActiveTransport, types::SendDataOutcome},
     packages::package_store,
     probes::{counter, fingerprint_store},
-    wifi::manager::WifiCmd,
 };
 
 #[embassy_executor::task]
 pub async fn uploader_task(
     mut transport: ActiveTransport,
-    wifi_command_sender: Sender<'static, CriticalSectionRawMutex, WifiCmd, 4>,
+    network_command_receiver: Receiver<'static, CriticalSectionRawMutex, SystemCmd, 4>,
+    orchestrator_event_publisher: Publisher<
+        'static,
+        CriticalSectionRawMutex,
+        SystemEvents,
+        4,
+        1,
+        2,
+    >,
 ) {
-    const PERIOD: Duration = Duration::from_secs(180); // Change for testing reasons.
     const SEND_TIMEOUT: Duration = Duration::from_secs(30);
     const RETRY_DELAY: Duration = Duration::from_millis(500);
-    const RADIO_SETTLE_DELAY: Duration = Duration::from_secs(5);
     const SEND_ATTEMPTS: u8 = 5;
 
-    wifi_command_sender.send(WifiCmd::StartSniffing).await;
-
     loop {
-        Timer::after(PERIOD).await;
+        let command = network_command_receiver.receive().await;
 
-        match transport.ensure_connected().await {
-            ConnectionOutcome::Connected => {
-                info!("Connection Established")
-            }
-            ConnectionOutcome::Failure | ConnectionOutcome::Disconnected => {
-                error!("Connection timeout");
-                continue;
-            }
-        }
-
-        let fingerprint_snapshot = fingerprint_store::snapshot();
-        let curr_count = counter::deduplicate_probes(&fingerprint_snapshot);
-        package_store::push(curr_count); // TODO: implement limit to avoid buffer overflow of http request. Basically use chunking.
-        fingerprint_store::drain();
-
-        wifi_command_sender.send(WifiCmd::StopSniffing).await;
-        Timer::after(RADIO_SETTLE_DELAY).await;
-
-        let mut ok = false;
-        for attempt in 0..SEND_ATTEMPTS {
-            let packages = package_store::snapshot_with_age();
-
-            match transport
-                .send_data(packages)
-                .with_timeout(SEND_TIMEOUT)
-                .await
-            {
-                Ok(SendDataOutcome::Success) => {
-                    package_store::drain();
-                    ok = true;
-                    break;
+        if command == SystemCmd::Connect {
+            match transport.ensure_connected().await {
+                ConnectionOutcome::Connected => {
+                    info!("Connection Established");
+                    orchestrator_event_publisher
+                        .publish(SystemEvents::Upload(UploadEvents::NetworkConnected))
+                        .await;
+                    continue;
                 }
-                Ok(SendDataOutcome::RetryableFailure) => {
-                    error!("Data sending had a retriable failure");
+                ConnectionOutcome::Failure | ConnectionOutcome::Disconnected => {
+                    error!("Connection timeout");
+                    orchestrator_event_publisher
+                        .publish(SystemEvents::Upload(UploadEvents::NetworkError))
+                        .await;
+                    continue;
                 }
-                Ok(SendDataOutcome::FatalFailure) => {
-                    error!("HTTP send failed");
-                    ok = false;
-                    break;
+            }
+        } else if command == SystemCmd::UploadData {
+            let fingerprint_snapshot = fingerprint_store::snapshot();
+            let curr_count = counter::deduplicate_probes(&fingerprint_snapshot);
+            package_store::push(curr_count); // TODO: implement limit to avoid buffer overflow of http request. Basically use chunking.
+            fingerprint_store::drain();
+
+            let mut ok = false;
+            for attempt in 0..SEND_ATTEMPTS {
+                let packages = package_store::snapshot_with_age();
+
+                match transport
+                    .send_data(packages)
+                    .with_timeout(SEND_TIMEOUT)
+                    .await
+                {
+                    Ok(SendDataOutcome::Success) => {
+                        package_store::drain();
+                        ok = true;
+                        break;
+                    }
+                    Ok(SendDataOutcome::RetryableFailure) => {
+                        error!("Data sending had a retriable failure");
+                    }
+                    Ok(SendDataOutcome::FatalFailure) => {
+                        error!("HTTP send failed");
+                        ok = false;
+                        break;
+                    }
+                    Ok(SendDataOutcome::BackoffRequired) => {
+                        info!(
+                            "Transport recovery/backoff in progress; skipping remaining attempts this cycle"
+                        );
+                        break;
+                    }
+                    Err(_) => error!("Package sending timed out"),
                 }
-                Ok(SendDataOutcome::BackoffRequired) => {
-                    info!(
-                        "Transport recovery/backoff in progress; skipping remaining attempts this cycle"
-                    );
-                    break;
+
+                if attempt + 1 < SEND_ATTEMPTS {
+                    Timer::after(RETRY_DELAY).await;
                 }
-                Err(_) => error!("Package sending timed out"),
             }
 
-            if attempt + 1 < SEND_ATTEMPTS {
-                Timer::after(RETRY_DELAY).await;
+            if ok {
+                orchestrator_event_publisher
+                    .publish(SystemEvents::Upload(UploadEvents::UploadSuccessfull))
+                    .await;
+                info!("Package sent successfully");
+            } else {
+                orchestrator_event_publisher
+                    .publish(SystemEvents::Upload(UploadEvents::UploadError))
+                    .await;
+                error!("Package sending failed");
             }
-        }
-
-        wifi_command_sender.send(WifiCmd::StartSniffing).await;
-
-        if ok {
-            info!("Package sent successfully");
-        } else {
-            error!("Package sending failed");
         }
     }
 }

--- a/trailsense-edge/src/network/uploader.rs
+++ b/trailsense-edge/src/network/uploader.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 use crate::{
     network::{TransportControl, UplinkTransport, types::ConnectionOutcome},
-    orchestration::types::{DataEvents, SystemCmd, SystemEvents, TransportEvents, UploadEvents},
+    orchestration::types::{DataEvents, SystemCmd, SystemEvents, UploadEvents},
 };
 use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex, channel::Receiver, pubsub::Publisher,
@@ -26,7 +26,7 @@ pub async fn uploader_task(
         SystemEvents,
         4,
         1,
-        2,
+        3,
     >,
 ) {
     const SEND_TIMEOUT: Duration = Duration::from_secs(30);
@@ -39,21 +39,9 @@ pub async fn uploader_task(
         match command {
             SystemCmd::SetTransportEnabled { id, enabled } => {
                 if enabled {
-                    transport.control(TransportControl::Enable).await;
-                    orchestrator_event_publisher
-                        .publish(SystemEvents::Transport {
-                            id,
-                            event: TransportEvents::TransportEnabled,
-                        })
-                        .await;
+                    transport.control(TransportControl::Enable, id).await;
                 } else {
-                    transport.control(TransportControl::Disable).await;
-                    orchestrator_event_publisher
-                        .publish(SystemEvents::Transport {
-                            id,
-                            event: TransportEvents::TransportDisabled,
-                        })
-                        .await;
+                    transport.control(TransportControl::Disable, id).await;
                 }
             }
             SystemCmd::Connect { id } => {

--- a/trailsense-edge/src/network/uploader.rs
+++ b/trailsense-edge/src/network/uploader.rs
@@ -1,8 +1,8 @@
 extern crate alloc;
 
 use crate::{
-    network::{UplinkTransport, types::ConnectionOutcome},
-    orchestration::types::{SystemCmd, SystemEvents, UploadEvents},
+    network::{TransportControl, UplinkTransport, types::ConnectionOutcome},
+    orchestration::types::{SystemCmd, SystemEvents, TransportEvents, UploadEvents},
 };
 use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex, channel::Receiver, pubsub::Publisher,
@@ -37,6 +37,25 @@ pub async fn uploader_task(
         let command = network_command_receiver.receive().await;
 
         match command {
+            SystemCmd::SetTransportEnabled { id, enabled } => {
+                if enabled {
+                    transport.control(TransportControl::Enable).await;
+                    orchestrator_event_publisher
+                        .publish(SystemEvents::Transport {
+                            id,
+                            event: TransportEvents::TransportEnabled,
+                        })
+                        .await;
+                } else {
+                    transport.control(TransportControl::Disable).await;
+                    orchestrator_event_publisher
+                        .publish(SystemEvents::Transport {
+                            id,
+                            event: TransportEvents::TransportDisabled,
+                        })
+                        .await;
+                }
+            }
             SystemCmd::Connect { id } => {
                 info!("UPL: recv Connect id={}", id.0);
                 match transport.ensure_connected().await {

--- a/trailsense-edge/src/network/uploader.rs
+++ b/trailsense-edge/src/network/uploader.rs
@@ -36,75 +36,83 @@ pub async fn uploader_task(
     loop {
         let command = network_command_receiver.receive().await;
 
-        if command == SystemCmd::Connect {
-            match transport.ensure_connected().await {
-                ConnectionOutcome::Connected => {
-                    info!("Connection Established");
-                    orchestrator_event_publisher
-                        .publish(SystemEvents::Upload(UploadEvents::NetworkConnected))
-                        .await;
-                    continue;
-                }
-                ConnectionOutcome::Failure | ConnectionOutcome::Disconnected => {
-                    error!("Connection timeout");
-                    orchestrator_event_publisher
-                        .publish(SystemEvents::Upload(UploadEvents::NetworkError))
-                        .await;
-                    continue;
-                }
-            }
-        } else if command == SystemCmd::UploadData {
-            let fingerprint_snapshot = fingerprint_store::snapshot();
-            let curr_count = counter::deduplicate_probes(&fingerprint_snapshot);
-            package_store::push(curr_count); // TODO: implement limit to avoid buffer overflow of http request. Basically use chunking.
-            fingerprint_store::drain();
-
-            let mut ok = false;
-            for attempt in 0..SEND_ATTEMPTS {
-                let packages = package_store::snapshot_with_age();
-
-                match transport
-                    .send_data(packages)
-                    .with_timeout(SEND_TIMEOUT)
-                    .await
-                {
-                    Ok(SendDataOutcome::Success) => {
-                        package_store::drain();
-                        ok = true;
-                        break;
+        match command {
+            SystemCmd::Connect { id } => {
+                info!("UPL: recv Connect id={}", id.0);
+                match transport.ensure_connected().await {
+                    ConnectionOutcome::Connected => {
+                        orchestrator_event_publisher
+                            .publish(SystemEvents::Upload {
+                                id,
+                                event: UploadEvents::NetworkConnected,
+                            })
+                            .await;
                     }
-                    Ok(SendDataOutcome::RetryableFailure) => {
-                        error!("Data sending had a retriable failure");
+                    ConnectionOutcome::Failure | ConnectionOutcome::Disconnected => {
+                        orchestrator_event_publisher
+                            .publish(SystemEvents::Upload {
+                                id,
+                                event: UploadEvents::NetworkError,
+                            })
+                            .await;
                     }
-                    Ok(SendDataOutcome::FatalFailure) => {
-                        error!("HTTP send failed");
-                        ok = false;
-                        break;
-                    }
-                    Ok(SendDataOutcome::BackoffRequired) => {
-                        info!(
-                            "Transport recovery/backoff in progress; skipping remaining attempts this cycle"
-                        );
-                        break;
-                    }
-                    Err(_) => error!("Package sending timed out"),
-                }
-
-                if attempt + 1 < SEND_ATTEMPTS {
-                    Timer::after(RETRY_DELAY).await;
                 }
             }
 
-            if ok {
+            SystemCmd::UploadData { id } => {
+                info!("UPL: recv UploadData id={}", id.0);
+                let fingerprint_snapshot = fingerprint_store::snapshot();
+                let curr_count = counter::deduplicate_probes(&fingerprint_snapshot);
+                package_store::push(curr_count); // TODO: implement limit to avoid buffer overflow of http request. Basically use chunking.
+                fingerprint_store::drain();
+
+                let mut ok = false;
+                for attempt in 0..SEND_ATTEMPTS {
+                    let packages = package_store::snapshot_with_age();
+
+                    match transport
+                        .send_data(packages)
+                        .with_timeout(SEND_TIMEOUT)
+                        .await
+                    {
+                        Ok(SendDataOutcome::Success) => {
+                            package_store::drain();
+                            ok = true;
+                            break;
+                        }
+                        Ok(SendDataOutcome::RetryableFailure) => {
+                            error!("UPL: id={} data sending had retryable failure", id.0);
+                        }
+                        Ok(SendDataOutcome::FatalFailure) => {
+                            error!("HTTP send failed");
+                            ok = false;
+                            break;
+                        }
+                        Ok(SendDataOutcome::BackoffRequired) => {
+                            info!("UPL: id={} backoff required; recovery pending", id.0);
+                            break;
+                        }
+                        Err(_) => error!("Package sending timed out"),
+                    }
+
+                    if attempt + 1 < SEND_ATTEMPTS {
+                        Timer::after(RETRY_DELAY).await;
+                    }
+                }
+
+                let event = if ok {
+                    UploadEvents::UploadSuccessful
+                } else {
+                    UploadEvents::UploadError
+                };
+
                 orchestrator_event_publisher
-                    .publish(SystemEvents::Upload(UploadEvents::UploadSuccessfull))
+                    .publish(SystemEvents::Upload { id, event })
                     .await;
-                info!("Package sent successfully");
-            } else {
-                orchestrator_event_publisher
-                    .publish(SystemEvents::Upload(UploadEvents::UploadError))
-                    .await;
-                error!("Package sending failed");
+            }
+
+            _ => {
+                // ignore commands not handled by uploader
             }
         }
     }

--- a/trailsense-edge/src/network/uploader.rs
+++ b/trailsense-edge/src/network/uploader.rs
@@ -2,7 +2,7 @@ extern crate alloc;
 
 use crate::{
     network::{TransportControl, UplinkTransport, types::ConnectionOutcome},
-    orchestration::types::{SystemCmd, SystemEvents, TransportEvents, UploadEvents},
+    orchestration::types::{DataEvents, SystemCmd, SystemEvents, TransportEvents, UploadEvents},
 };
 use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex, channel::Receiver, pubsub::Publisher,
@@ -127,6 +127,31 @@ pub async fn uploader_task(
 
                 orchestrator_event_publisher
                     .publish(SystemEvents::Upload { id, event })
+                    .await;
+            }
+
+            SystemCmd::SaveLocally { id } => {
+                info!("UPL: recv SaveLocally id={}", id.0);
+                let fingerprint_snapshot = fingerprint_store::snapshot();
+                let saved_ok = if fingerprint_snapshot.is_empty() {
+                    true
+                } else {
+                    let curr_count = counter::deduplicate_probes(&fingerprint_snapshot);
+                    let ok = package_store::push(curr_count);
+                    if ok {
+                        fingerprint_store::drain();
+                    }
+                    ok
+                };
+
+                let event = if saved_ok {
+                    DataEvents::DataSaved
+                } else {
+                    DataEvents::DataError
+                };
+
+                orchestrator_event_publisher
+                    .publish(SystemEvents::Data { id, event })
                     .await;
             }
 

--- a/trailsense-edge/src/network/wifi/transport.rs
+++ b/trailsense-edge/src/network/wifi/transport.rs
@@ -20,6 +20,7 @@ use crate::{
         TransportControl, UplinkTransport,
         types::{ConnectionOutcome, PackageDto, SendDataOutcome},
     },
+    orchestration::types::CorrelationId,
     packages::package_store::PackageEntity,
     wifi::{WifiCtx, tasks::WifiControlCmd, wait_for_connection},
 };
@@ -82,7 +83,7 @@ impl WifiTransport {
 }
 
 impl UplinkTransport for WifiTransport {
-    async fn control(&mut self, cmd: TransportControl) {
+    async fn control(&mut self, cmd: TransportControl, id: CorrelationId) {
         let enabled = matches!(cmd, TransportControl::Enable);
 
         self.auto_connect_enabled = enabled;
@@ -92,7 +93,7 @@ impl UplinkTransport for WifiTransport {
         }
 
         self.wifi_control_sender
-            .send(WifiControlCmd::EnableAutoConnect(enabled))
+            .send(WifiControlCmd::SetAutoConnect { enabled, id })
             .await;
     }
 
@@ -211,7 +212,8 @@ impl UplinkTransport for WifiTransport {
                                 self.dns_reconnect_threshold,
                                 self.dns_restart_threshold
                             );
-                            self.consecutive_dns_failures += 1;
+                            self.consecutive_dns_failures =
+                                self.consecutive_dns_failures.saturating_add(1);
                             return SendDataOutcome::RetryableFailure;
                         }
                         if attempt + 1 < REQUEST_BUILD_ATTEMPTS {
@@ -244,7 +246,7 @@ impl UplinkTransport for WifiTransport {
                         self.dns_reconnect_threshold,
                         self.dns_restart_threshold
                     );
-                    self.consecutive_dns_failures += 1;
+                    self.consecutive_dns_failures = self.consecutive_dns_failures.saturating_add(1);
                     return SendDataOutcome::RetryableFailure;
                 }
                 self.consecutive_dns_failures = 0;

--- a/trailsense-edge/src/network/wifi/transport.rs
+++ b/trailsense-edge/src/network/wifi/transport.rs
@@ -108,6 +108,7 @@ impl UplinkTransport for WifiTransport {
         }
 
         if self.consecutive_dns_failures >= self.dns_restart_threshold {
+            info!("NET: triggering Wi-Fi controller restart due to DNS failures");
             self.recovery_pending = true;
             self.wifi_control_sender
                 .send(WifiControlCmd::RestartController)
@@ -116,6 +117,8 @@ impl UplinkTransport for WifiTransport {
             return SendDataOutcome::BackoffRequired;
         }
         if self.consecutive_dns_failures >= self.dns_reconnect_threshold {
+            info!("NET: triggering Wi-Fi reconnect due to DNS failures");
+
             self.recovery_pending = true;
             self.wifi_control_sender
                 .send(WifiControlCmd::Reconnect)
@@ -179,6 +182,12 @@ impl UplinkTransport for WifiTransport {
                             e
                         );
                         if matches!(e, reqwless::Error::Dns) {
+                            error!(
+                                "NET: DNS failure count={}/{} restart_threshold={}",
+                                self.consecutive_dns_failures + 1,
+                                self.dns_reconnect_threshold,
+                                self.dns_restart_threshold
+                            );
                             self.consecutive_dns_failures += 1;
                             return SendDataOutcome::RetryableFailure;
                         }
@@ -206,6 +215,12 @@ impl UplinkTransport for WifiTransport {
                     e
                 );
                 if matches!(e, reqwless::Error::Dns) {
+                    error!(
+                        "NET: DNS failure count={}/{} restart_threshold={}",
+                        self.consecutive_dns_failures + 1,
+                        self.dns_reconnect_threshold,
+                        self.dns_restart_threshold
+                    );
                     self.consecutive_dns_failures += 1;
                     return SendDataOutcome::RetryableFailure;
                 }

--- a/trailsense-edge/src/network/wifi/transport.rs
+++ b/trailsense-edge/src/network/wifi/transport.rs
@@ -17,7 +17,7 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Sender
 
 use crate::{
     network::{
-        UplinkTransport,
+        TransportControl, UplinkTransport,
         types::{ConnectionOutcome, PackageDto, SendDataOutcome},
     },
     packages::package_store::PackageEntity,
@@ -59,6 +59,7 @@ pub struct WifiTransport {
     dns_restart_threshold: u8,
     wifi_control_sender: Sender<'static, CriticalSectionRawMutex, WifiControlCmd, 4>,
     recovery_pending: bool,
+    auto_connect_enabled: bool,
 }
 
 impl WifiTransport {
@@ -75,14 +76,32 @@ impl WifiTransport {
             dns_reconnect_threshold: config.dns_reconnect_threshold,
             dns_restart_threshold: config.dns_restart_threshold,
             wifi_control_sender: wifi_control_sender,
+            auto_connect_enabled: true,
         }
     }
 }
 
 impl UplinkTransport for WifiTransport {
-    async fn ensure_connected(&mut self) -> ConnectionOutcome {
-        const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
+    async fn control(&mut self, cmd: TransportControl) {
+        let enabled = matches!(cmd, TransportControl::Enable);
 
+        self.auto_connect_enabled = enabled;
+
+        if !enabled {
+            self.recovery_pending = false;
+        }
+
+        self.wifi_control_sender
+            .send(WifiControlCmd::EnableAutoConnect(enabled))
+            .await;
+    }
+
+    async fn ensure_connected(&mut self) -> ConnectionOutcome {
+        if !self.auto_connect_enabled {
+            return ConnectionOutcome::Disconnected;
+        }
+
+        const CONNECT_TIMEOUT: Duration = Duration::from_secs(15);
         let was_recovering = self.recovery_pending;
 
         if wait_for_connection(self.stack)
@@ -103,6 +122,10 @@ impl UplinkTransport for WifiTransport {
         ConnectionOutcome::Connected
     }
     async fn send_data(&mut self, packages: Vec<PackageEntity>) -> SendDataOutcome {
+        if !self.auto_connect_enabled {
+            return SendDataOutcome::BackoffRequired;
+        }
+
         if self.recovery_pending {
             return SendDataOutcome::BackoffRequired;
         }

--- a/trailsense-edge/src/orchestration/mod.rs
+++ b/trailsense-edge/src/orchestration/mod.rs
@@ -1,0 +1,2 @@
+pub mod orchestrator;
+pub mod types;

--- a/trailsense-edge/src/orchestration/orchestrator.rs
+++ b/trailsense-edge/src/orchestration/orchestrator.rs
@@ -31,7 +31,7 @@ enum WaitResult<T> {
 /// # Wait For SystemEvent
 /// This function helps to add a timeout when sending a system command and waiting for an event as a response
 async fn wait_for<T, F>(
-    sub: &mut Subscriber<'static, CriticalSectionRawMutex, SystemEvents, 4, 1, 2>,
+    sub: &mut Subscriber<'static, CriticalSectionRawMutex, SystemEvents, 4, 1, 3>,
     timeout: Duration,
     mut map: F,
 ) -> WaitResult<T>
@@ -69,15 +69,15 @@ where
 /// As soon as all the hardware is initialized, the orchestrator can take over and handle the state. Technically the state coming in should always be idle.
 #[embassy_executor::task]
 pub async fn orchestrate_node(
-    mut event_subscriber: Subscriber<'static, CriticalSectionRawMutex, SystemEvents, 4, 1, 2>,
+    mut event_subscriber: Subscriber<'static, CriticalSectionRawMutex, SystemEvents, 4, 1, 3>,
     network_sender: Sender<'static, CriticalSectionRawMutex, SystemCmd, 4>,
     sniffer_sender: Sender<'static, CriticalSectionRawMutex, SystemCmd, 4>,
     state: SystemState,
 ) {
     let mut current_state = state;
-    let mut network_error_count = 0;
-    let mut save_failure_count = 0;
-    let mut network_fallback_count = 0;
+    let mut network_error_count: u8 = 0;
+    let mut save_failure_count: u8 = 0;
+    let mut network_fallback_count: u8 = 0;
     let mut uplink_transport_enabled = false;
 
     let mut next_id: u32 = 1;
@@ -245,7 +245,7 @@ pub async fn orchestrate_node(
                 {
                     WaitResult::Matched(true) => current_state = SystemState::Uploading,
                     WaitResult::Matched(false) | WaitResult::Timeout => {
-                        network_error_count += 1;
+                        network_error_count = network_error_count.saturating_add(1);
                         current_state = if network_error_count >= NETWORK_LIMIT {
                             SystemState::SavingData
                         } else {
@@ -286,7 +286,7 @@ pub async fn orchestrate_node(
                         current_state = SystemState::Idle;
                     }
                     WaitResult::Matched(Err(())) | WaitResult::Timeout => {
-                        network_error_count += 1;
+                        network_error_count = network_error_count.saturating_add(1);
                         current_state = if network_error_count >= NETWORK_LIMIT {
                             SystemState::SavingData
                         } else {
@@ -296,7 +296,7 @@ pub async fn orchestrate_node(
                 }
             }
             SystemState::SavingData => {
-                // Currently saves into RAM and not persistent storage. Need to think if that is necesary.
+                // Currently saves into RAM and not persistent storage. Need to think if that is necessary.
                 if uplink_transport_enabled {
                     let transport_id = new_id();
 
@@ -347,12 +347,12 @@ pub async fn orchestrate_node(
                 {
                     WaitResult::Matched(true) => {
                         current_state = SystemState::Idle;
-                        network_fallback_count += 1;
+                        network_fallback_count = network_fallback_count.saturating_add(1);
                         save_failure_count = 0;
                     }
                     WaitResult::Matched(false) | WaitResult::Timeout => {
                         error!("Issue saving data locally");
-                        save_failure_count += 1;
+                        save_failure_count = save_failure_count.saturating_add(1);
                         current_state = SystemState::SavingData;
                     }
                 }
@@ -367,6 +367,9 @@ pub async fn orchestrate_node(
             }
             SystemState::Sleep => {
                 // TODO: Implement real deep sleep. For now just take a X min break.
+
+                // Reset network error count, so that after sleep it can retry connecting.
+                network_error_count = 0;
                 Timer::after(PERIOD).await;
                 current_state = SystemState::Idle;
             }

--- a/trailsense-edge/src/orchestration/orchestrator.rs
+++ b/trailsense-edge/src/orchestration/orchestrator.rs
@@ -1,0 +1,200 @@
+extern crate alloc;
+
+use embassy_futures::select::{Either, select};
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex, channel::Sender, pubsub::Subscriber,
+};
+use embassy_time::{Duration, Timer};
+use log::error;
+
+use crate::orchestration::types::{
+    DataEvents, SnifferEvents, SystemCmd, SystemEvents, SystemState, UploadEvents,
+};
+
+const PERIOD: Duration = Duration::from_secs(180); // Change for testing reasons.
+const NETWORK_LIMIT: u8 = 5;
+const MAX_LOCAL_SAVES: u8 = 10;
+const MAX_SAVE_FAILURES: u8 = 5;
+const GENERAL_TIMEOUT: Duration = Duration::from_secs(8);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
+const STOP_SNIFF_TIMEOUT: Duration = Duration::from_secs(8);
+const UPLOAD_TIMEOUT: Duration = Duration::from_secs(35);
+
+enum WaitResult<T> {
+    Matched(T),
+    Timeout,
+}
+
+// Waits until a matching event arrives; ignores unrelated events.
+async fn wait_for<T, F>(
+    sub: &mut Subscriber<'static, CriticalSectionRawMutex, SystemEvents, 4, 1, 2>,
+    timeout: Duration,
+    mut map: F,
+) -> WaitResult<T>
+where
+    F: FnMut(SystemEvents) -> Option<T>,
+{
+    loop {
+        match select(Timer::after(timeout), sub.next_message_pure()).await {
+            Either::First(_) => return WaitResult::Timeout,
+            Either::Second(ev) => {
+                if let Some(v) = map(ev) {
+                    return WaitResult::Matched(v);
+                } else {
+                    // unrelated event from mixed stream; ignore
+                    log::debug!("Ignoring unrelated event while waiting");
+                }
+            }
+        }
+    }
+}
+
+/// # Node Orchestrator Task
+///
+/// This task handles state changes and instructs different parts of the system to do their part of the work
+///
+/// **Little Side Note:** I think the main function should do the hardware initialization, and crash early if necessary etc.
+/// As soon as all the hardware is initialized, the orchestrator can take over and handle the state. Technically the state coming in should always be idle.
+#[embassy_executor::task]
+pub async fn orchestrate_node(
+    mut event_subscriber: Subscriber<'static, CriticalSectionRawMutex, SystemEvents, 4, 1, 2>,
+    network_sender: Sender<'static, CriticalSectionRawMutex, SystemCmd, 4>,
+    sniffer_sender: Sender<'static, CriticalSectionRawMutex, SystemCmd, 4>,
+    state: SystemState,
+) {
+    let mut current_state = state;
+    let mut network_error_count = 0;
+    let mut save_failure_count = 0;
+    let mut network_fallback_count = 0;
+    loop {
+        match current_state {
+            SystemState::Idle => {
+                // TODO: add any further init or whatever else is needed to be here.
+                current_state = SystemState::Sniffing;
+            }
+            SystemState::Sniffing => {
+                sniffer_sender.send(SystemCmd::StartSniffing).await;
+
+                match wait_for(&mut event_subscriber, GENERAL_TIMEOUT, |e| match e {
+                    SystemEvents::Sniffer(SnifferEvents::StartedSniffing) => Some(true),
+                    SystemEvents::Sniffer(SnifferEvents::SniffingError) => Some(false),
+                    _ => None,
+                })
+                .await
+                {
+                    WaitResult::Matched(true) => {
+                        match wait_for(&mut event_subscriber, PERIOD, |e| match e {
+                            SystemEvents::Sniffer(SnifferEvents::SniffingError) => Some(()),
+                            _ => None,
+                        })
+                        .await
+                        {
+                            WaitResult::Timeout => current_state = SystemState::PreparingUpload, // period done
+                            WaitResult::Matched(()) => current_state = SystemState::Sniffing, // recover/retry
+                        }
+                    }
+                    WaitResult::Matched(false) | WaitResult::Timeout => {
+                        current_state = SystemState::Sniffing; // retry policy
+                    }
+                }
+            }
+            SystemState::PreparingUpload => {
+                sniffer_sender.send(SystemCmd::StopSniffing).await;
+
+                match wait_for(&mut event_subscriber, STOP_SNIFF_TIMEOUT, |e| match e {
+                    SystemEvents::Sniffer(SnifferEvents::StoppedSniffing) => Some(true),
+                    SystemEvents::Sniffer(SnifferEvents::SniffingError) => Some(false),
+                    _ => None,
+                })
+                .await
+                {
+                    WaitResult::Matched(true) => current_state = SystemState::Connecting,
+                    WaitResult::Matched(false) => current_state = SystemState::Sniffing,
+                    WaitResult::Timeout => current_state = SystemState::Sniffing,
+                }
+            }
+            SystemState::Connecting => {
+                network_sender.send(SystemCmd::Connect).await;
+
+                match wait_for(&mut event_subscriber, CONNECT_TIMEOUT, |e| match e {
+                    SystemEvents::Upload(UploadEvents::NetworkConnected) => Some(true),
+                    SystemEvents::Upload(UploadEvents::NetworkError) => Some(false),
+                    _ => None,
+                })
+                .await
+                {
+                    WaitResult::Matched(true) => current_state = SystemState::Uploading,
+                    WaitResult::Matched(false) | WaitResult::Timeout => {
+                        network_error_count += 1;
+                        current_state = if network_error_count >= NETWORK_LIMIT {
+                            SystemState::SavingData
+                        } else {
+                            SystemState::Sniffing
+                        };
+                    }
+                }
+            }
+            SystemState::Uploading => {
+                network_sender.send(SystemCmd::UploadData).await;
+                match wait_for(&mut event_subscriber, UPLOAD_TIMEOUT, |e| match e {
+                    SystemEvents::Upload(UploadEvents::UploadSuccessfull) => Some(Ok(())),
+                    SystemEvents::Upload(UploadEvents::UploadError)
+                    | SystemEvents::Upload(UploadEvents::NetworkError) => Some(Err(())),
+                    _ => None,
+                })
+                .await
+                {
+                    WaitResult::Matched(Ok(())) => {
+                        network_error_count = 0;
+                        save_failure_count = 0;
+                        network_fallback_count = 0;
+                        current_state = SystemState::Idle;
+                    }
+                    WaitResult::Matched(Err(())) | WaitResult::Timeout => {
+                        network_error_count += 1;
+                        current_state = if network_error_count >= NETWORK_LIMIT {
+                            SystemState::SavingData
+                        } else {
+                            SystemState::Connecting
+                        };
+                    }
+                }
+            }
+            SystemState::SavingData => {
+                network_sender.send(SystemCmd::SaveLocally).await;
+
+                match wait_for(&mut event_subscriber, GENERAL_TIMEOUT, |e| match e {
+                    SystemEvents::Data(DataEvents::DataSaved) => Some(true),
+                    SystemEvents::Data(DataEvents::DataError) => Some(false),
+                    _ => None,
+                })
+                .await
+                {
+                    WaitResult::Matched(true) => {
+                        current_state = SystemState::Idle;
+                        network_fallback_count += 1;
+                        save_failure_count = 0;
+                    }
+                    WaitResult::Matched(false) | WaitResult::Timeout => {
+                        error!("Issue saving data locally");
+                        save_failure_count += 1;
+                        current_state = SystemState::SavingData;
+                    }
+                }
+
+                if network_fallback_count >= MAX_LOCAL_SAVES
+                    || save_failure_count >= MAX_SAVE_FAILURES
+                {
+                    network_fallback_count = 0;
+                    save_failure_count = 0;
+                    current_state = SystemState::Sleep;
+                }
+            }
+            SystemState::Sleep => {
+                // TODO: Implement real deep sleep. For now just take a X min break.
+                Timer::after(PERIOD).await;
+                current_state = SystemState::Idle;
+            }
+        }
+    }
+}

--- a/trailsense-edge/src/orchestration/orchestrator.rs
+++ b/trailsense-edge/src/orchestration/orchestrator.rs
@@ -5,10 +5,10 @@ use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex, channel::Sender, pubsub::Subscriber,
 };
 use embassy_time::{Duration, Timer};
-use log::error;
+use log::{debug, error, info};
 
 use crate::orchestration::types::{
-    DataEvents, SnifferEvents, SystemCmd, SystemEvents, SystemState, UploadEvents,
+    CorrelationId, DataEvents, SnifferEvents, SystemCmd, SystemEvents, SystemState, UploadEvents,
 };
 
 const PERIOD: Duration = Duration::from_secs(180); // Change for testing reasons.
@@ -42,7 +42,7 @@ where
                     return WaitResult::Matched(v);
                 } else {
                     // unrelated event from mixed stream; ignore
-                    log::debug!("Ignoring unrelated event while waiting");
+                    debug!("FSM: ignored unrelated event while waiting");
                 }
             }
         }
@@ -66,6 +66,14 @@ pub async fn orchestrate_node(
     let mut network_error_count = 0;
     let mut save_failure_count = 0;
     let mut network_fallback_count = 0;
+
+    let mut next_id: u32 = 1;
+    let mut new_id = || {
+        let id = CorrelationId(next_id);
+        next_id = next_id.wrapping_add(1);
+        id
+    };
+
     loop {
         match current_state {
             SystemState::Idle => {
@@ -73,18 +81,29 @@ pub async fn orchestrate_node(
                 current_state = SystemState::Sniffing;
             }
             SystemState::Sniffing => {
-                sniffer_sender.send(SystemCmd::StartSniffing).await;
+                let id = new_id();
+                info!("FSM: state=Sniffing send StartSniffing id={}", id.0);
+                sniffer_sender.send(SystemCmd::StartSniffing { id }).await;
 
                 match wait_for(&mut event_subscriber, GENERAL_TIMEOUT, |e| match e {
-                    SystemEvents::Sniffer(SnifferEvents::StartedSniffing) => Some(true),
-                    SystemEvents::Sniffer(SnifferEvents::SniffingError) => Some(false),
+                    SystemEvents::Sniffer {
+                        id: ev_id,
+                        event: SnifferEvents::StartedSniffing,
+                    } if ev_id == id => Some(true),
+                    SystemEvents::Sniffer {
+                        id: ev_id,
+                        event: SnifferEvents::SniffingError,
+                    } if ev_id == id => Some(false),
                     _ => None,
                 })
                 .await
                 {
                     WaitResult::Matched(true) => {
                         match wait_for(&mut event_subscriber, PERIOD, |e| match e {
-                            SystemEvents::Sniffer(SnifferEvents::SniffingError) => Some(()),
+                            SystemEvents::Sniffer {
+                                id: ev_id,
+                                event: SnifferEvents::SniffingError,
+                            } if ev_id == id => Some(()),
                             _ => None,
                         })
                         .await
@@ -99,11 +118,19 @@ pub async fn orchestrate_node(
                 }
             }
             SystemState::PreparingUpload => {
-                sniffer_sender.send(SystemCmd::StopSniffing).await;
+                let id = new_id();
+                info!("FSM: state=PreparingUpload send StopSniffing id={}", id.0);
+                sniffer_sender.send(SystemCmd::StopSniffing { id }).await;
 
                 match wait_for(&mut event_subscriber, STOP_SNIFF_TIMEOUT, |e| match e {
-                    SystemEvents::Sniffer(SnifferEvents::StoppedSniffing) => Some(true),
-                    SystemEvents::Sniffer(SnifferEvents::SniffingError) => Some(false),
+                    SystemEvents::Sniffer {
+                        id: ev_id,
+                        event: SnifferEvents::StoppedSniffing,
+                    } if ev_id == id => Some(true),
+                    SystemEvents::Sniffer {
+                        id: ev_id,
+                        event: SnifferEvents::SniffingError,
+                    } if ev_id == id => Some(false),
                     _ => None,
                 })
                 .await
@@ -114,11 +141,22 @@ pub async fn orchestrate_node(
                 }
             }
             SystemState::Connecting => {
-                network_sender.send(SystemCmd::Connect).await;
+                let id = new_id();
+                info!(
+                    "FSM: state=Connecting send Connect id={} retry={}",
+                    id.0, network_error_count
+                );
+                network_sender.send(SystemCmd::Connect { id }).await;
 
                 match wait_for(&mut event_subscriber, CONNECT_TIMEOUT, |e| match e {
-                    SystemEvents::Upload(UploadEvents::NetworkConnected) => Some(true),
-                    SystemEvents::Upload(UploadEvents::NetworkError) => Some(false),
+                    SystemEvents::Upload {
+                        id: ev_id,
+                        event: UploadEvents::NetworkConnected,
+                    } if ev_id == id => Some(true),
+                    SystemEvents::Upload {
+                        id: ev_id,
+                        event: UploadEvents::NetworkError,
+                    } if ev_id == id => Some(false),
                     _ => None,
                 })
                 .await
@@ -129,17 +167,32 @@ pub async fn orchestrate_node(
                         current_state = if network_error_count >= NETWORK_LIMIT {
                             SystemState::SavingData
                         } else {
-                            SystemState::Sniffing
+                            Timer::after(Duration::from_secs(2)).await;
+                            SystemState::Connecting
                         };
                     }
                 }
             }
             SystemState::Uploading => {
-                network_sender.send(SystemCmd::UploadData).await;
+                let id = new_id();
+                info!(
+                    "FSM: state=Uploading send UploadData id={} retry={}",
+                    id.0, network_error_count
+                );
+                network_sender.send(SystemCmd::UploadData { id }).await;
                 match wait_for(&mut event_subscriber, UPLOAD_TIMEOUT, |e| match e {
-                    SystemEvents::Upload(UploadEvents::UploadSuccessfull) => Some(Ok(())),
-                    SystemEvents::Upload(UploadEvents::UploadError)
-                    | SystemEvents::Upload(UploadEvents::NetworkError) => Some(Err(())),
+                    SystemEvents::Upload {
+                        id: ev_id,
+                        event: UploadEvents::UploadSuccessful,
+                    } if ev_id == id => Some(Ok(())),
+                    SystemEvents::Upload {
+                        id: ev_id,
+                        event: UploadEvents::UploadError,
+                    }
+                    | SystemEvents::Upload {
+                        id: ev_id,
+                        event: UploadEvents::NetworkError,
+                    } if ev_id == id => Some(Err(())),
                     _ => None,
                 })
                 .await
@@ -161,11 +214,22 @@ pub async fn orchestrate_node(
                 }
             }
             SystemState::SavingData => {
-                network_sender.send(SystemCmd::SaveLocally).await;
+                let id = new_id();
+                info!(
+                    "FSM: state=SavingData send SaveLocally id={} save_failures={}",
+                    id.0, save_failure_count
+                );
+                network_sender.send(SystemCmd::SaveLocally { id }).await;
 
                 match wait_for(&mut event_subscriber, GENERAL_TIMEOUT, |e| match e {
-                    SystemEvents::Data(DataEvents::DataSaved) => Some(true),
-                    SystemEvents::Data(DataEvents::DataError) => Some(false),
+                    SystemEvents::Data {
+                        id: ev_id,
+                        event: DataEvents::DataSaved,
+                    } if ev_id == id => Some(true),
+                    SystemEvents::Data {
+                        id: ev_id,
+                        event: DataEvents::DataError,
+                    } if ev_id == id => Some(false),
                     _ => None,
                 })
                 .await

--- a/trailsense-edge/src/orchestration/orchestrator.rs
+++ b/trailsense-edge/src/orchestration/orchestrator.rs
@@ -4,7 +4,7 @@ use embassy_futures::select::{Either, select};
 use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex, channel::Sender, pubsub::Subscriber,
 };
-use embassy_time::{Duration, Timer};
+use embassy_time::{Duration, Instant, Timer};
 use log::{debug, error, info};
 
 use crate::orchestration::types::{
@@ -27,6 +27,9 @@ enum WaitResult<T> {
 }
 
 // Waits until a matching event arrives; ignores unrelated events.
+
+/// # Wait For SystemEvent
+/// This function helps to add a timeout when sending a system command and waiting for an event as a response
 async fn wait_for<T, F>(
     sub: &mut Subscriber<'static, CriticalSectionRawMutex, SystemEvents, 4, 1, 2>,
     timeout: Duration,
@@ -35,14 +38,22 @@ async fn wait_for<T, F>(
 where
     F: FnMut(SystemEvents) -> Option<T>,
 {
+    let deadline = Instant::now() + timeout;
+
     loop {
-        match select(Timer::after(timeout), sub.next_message_pure()).await {
+        let now = Instant::now();
+        if now >= deadline {
+            return WaitResult::Timeout;
+        }
+
+        let remaining = deadline - now;
+
+        match select(Timer::after(remaining), sub.next_message_pure()).await {
             Either::First(_) => return WaitResult::Timeout,
             Either::Second(ev) => {
                 if let Some(v) = map(ev) {
                     return WaitResult::Matched(v);
                 } else {
-                    // unrelated event from mixed stream; ignore
                     debug!("FSM: ignored unrelated event while waiting");
                 }
             }
@@ -84,10 +95,6 @@ pub async fn orchestrate_node(
             }
             SystemState::Sniffing => {
                 let transport_id: CorrelationId = new_id();
-                info!(
-                    "FSM: state=Sniffing send StartSniffing id={}",
-                    transport_id.0
-                );
 
                 network_sender
                     .send(SystemCmd::SetTransportEnabled {
@@ -116,6 +123,10 @@ pub async fn orchestrate_node(
                 uplink_transport_enabled = false;
 
                 let sniffing_id = new_id();
+                info!(
+                    "FSM: state=Sniffing send StartSniffing id={}",
+                    sniffing_id.0
+                );
                 sniffer_sender
                     .send(SystemCmd::StartSniffing { id: sniffing_id })
                     .await;
@@ -175,9 +186,11 @@ pub async fn orchestrate_node(
                 })
                 .await
                 {
-                    WaitResult::Matched(true) => current_state = SystemState::Connecting,
-                    WaitResult::Matched(false) => current_state = SystemState::Sniffing,
-                    WaitResult::Timeout => current_state = SystemState::Sniffing,
+                    WaitResult::Matched(true) => {}
+                    WaitResult::Matched(false) | WaitResult::Timeout => {
+                        current_state = SystemState::Sniffing;
+                        continue;
+                    }
                 }
 
                 let transport_id = new_id();
@@ -200,6 +213,7 @@ pub async fn orchestrate_node(
                 {
                     WaitResult::Matched(()) => {
                         uplink_transport_enabled = true;
+                        current_state = SystemState::Connecting;
                     }
                     WaitResult::Timeout => {
                         error!("FSM: timeout waiting for transport enable ack");
@@ -282,6 +296,7 @@ pub async fn orchestrate_node(
                 }
             }
             SystemState::SavingData => {
+                // Currently saves into RAM and not persistent storage. Need to think if that is necesary.
                 if uplink_transport_enabled {
                     let transport_id = new_id();
 

--- a/trailsense-edge/src/orchestration/orchestrator.rs
+++ b/trailsense-edge/src/orchestration/orchestrator.rs
@@ -8,10 +8,11 @@ use embassy_time::{Duration, Timer};
 use log::{debug, error, info};
 
 use crate::orchestration::types::{
-    CorrelationId, DataEvents, SnifferEvents, SystemCmd, SystemEvents, SystemState, UploadEvents,
+    CorrelationId, DataEvents, SnifferEvents, SystemCmd, SystemEvents, SystemState,
+    TransportEvents, UploadEvents,
 };
 
-const PERIOD: Duration = Duration::from_secs(180); // Change for testing reasons.
+const PERIOD: Duration = Duration::from_secs(20); // Change for testing reasons.
 const NETWORK_LIMIT: u8 = 5;
 const MAX_LOCAL_SAVES: u8 = 10;
 const MAX_SAVE_FAILURES: u8 = 5;
@@ -66,6 +67,7 @@ pub async fn orchestrate_node(
     let mut network_error_count = 0;
     let mut save_failure_count = 0;
     let mut network_fallback_count = 0;
+    let mut uplink_transport_enabled = false;
 
     let mut next_id: u32 = 1;
     let mut new_id = || {
@@ -81,19 +83,51 @@ pub async fn orchestrate_node(
                 current_state = SystemState::Sniffing;
             }
             SystemState::Sniffing => {
-                let id = new_id();
-                info!("FSM: state=Sniffing send StartSniffing id={}", id.0);
-                sniffer_sender.send(SystemCmd::StartSniffing { id }).await;
+                let transport_id: CorrelationId = new_id();
+                info!(
+                    "FSM: state=Sniffing send StartSniffing id={}",
+                    transport_id.0
+                );
 
+                network_sender
+                    .send(SystemCmd::SetTransportEnabled {
+                        id: transport_id,
+                        enabled: false,
+                    })
+                    .await;
+
+                match wait_for(&mut event_subscriber, GENERAL_TIMEOUT, |e| match e {
+                    SystemEvents::Transport {
+                        id: ev_id,
+                        event: TransportEvents::TransportDisabled,
+                    } if ev_id == transport_id => Some(()),
+                    _ => None,
+                })
+                .await
+                {
+                    WaitResult::Matched(()) => {}
+                    WaitResult::Timeout => {
+                        error!("FSM: timeout waiting for transport disable ack");
+                        current_state = SystemState::Sniffing;
+                        continue;
+                    }
+                }
+
+                uplink_transport_enabled = false;
+
+                let sniffing_id = new_id();
+                sniffer_sender
+                    .send(SystemCmd::StartSniffing { id: sniffing_id })
+                    .await;
                 match wait_for(&mut event_subscriber, GENERAL_TIMEOUT, |e| match e {
                     SystemEvents::Sniffer {
                         id: ev_id,
                         event: SnifferEvents::StartedSniffing,
-                    } if ev_id == id => Some(true),
+                    } if ev_id == sniffing_id => Some(true),
                     SystemEvents::Sniffer {
                         id: ev_id,
                         event: SnifferEvents::SniffingError,
-                    } if ev_id == id => Some(false),
+                    } if ev_id == sniffing_id => Some(false),
                     _ => None,
                 })
                 .await
@@ -103,7 +137,7 @@ pub async fn orchestrate_node(
                             SystemEvents::Sniffer {
                                 id: ev_id,
                                 event: SnifferEvents::SniffingError,
-                            } if ev_id == id => Some(()),
+                            } if ev_id == sniffing_id => Some(()),
                             _ => None,
                         })
                         .await
@@ -118,19 +152,25 @@ pub async fn orchestrate_node(
                 }
             }
             SystemState::PreparingUpload => {
-                let id = new_id();
-                info!("FSM: state=PreparingUpload send StopSniffing id={}", id.0);
-                sniffer_sender.send(SystemCmd::StopSniffing { id }).await;
+                let sniffing_id = new_id();
+                info!(
+                    "FSM: state=PreparingUpload send StopSniffing id={}",
+                    sniffing_id.0
+                );
+
+                sniffer_sender
+                    .send(SystemCmd::StopSniffing { id: sniffing_id })
+                    .await;
 
                 match wait_for(&mut event_subscriber, STOP_SNIFF_TIMEOUT, |e| match e {
                     SystemEvents::Sniffer {
                         id: ev_id,
                         event: SnifferEvents::StoppedSniffing,
-                    } if ev_id == id => Some(true),
+                    } if ev_id == sniffing_id => Some(true),
                     SystemEvents::Sniffer {
                         id: ev_id,
                         event: SnifferEvents::SniffingError,
-                    } if ev_id == id => Some(false),
+                    } if ev_id == sniffing_id => Some(false),
                     _ => None,
                 })
                 .await
@@ -138,6 +178,34 @@ pub async fn orchestrate_node(
                     WaitResult::Matched(true) => current_state = SystemState::Connecting,
                     WaitResult::Matched(false) => current_state = SystemState::Sniffing,
                     WaitResult::Timeout => current_state = SystemState::Sniffing,
+                }
+
+                let transport_id = new_id();
+
+                network_sender
+                    .send(SystemCmd::SetTransportEnabled {
+                        id: transport_id,
+                        enabled: true,
+                    })
+                    .await;
+
+                match wait_for(&mut event_subscriber, GENERAL_TIMEOUT, |e| match e {
+                    SystemEvents::Transport {
+                        id: ev_id,
+                        event: TransportEvents::TransportEnabled,
+                    } if ev_id == transport_id => Some(()),
+                    _ => None,
+                })
+                .await
+                {
+                    WaitResult::Matched(()) => {
+                        uplink_transport_enabled = true;
+                    }
+                    WaitResult::Timeout => {
+                        error!("FSM: timeout waiting for transport enable ack");
+                        current_state = SystemState::Sniffing;
+                        continue;
+                    }
                 }
             }
             SystemState::Connecting => {
@@ -214,6 +282,34 @@ pub async fn orchestrate_node(
                 }
             }
             SystemState::SavingData => {
+                if uplink_transport_enabled {
+                    let transport_id = new_id();
+
+                    network_sender
+                        .send(SystemCmd::SetTransportEnabled {
+                            id: transport_id,
+                            enabled: false,
+                        })
+                        .await;
+
+                    match wait_for(&mut event_subscriber, GENERAL_TIMEOUT, |e| match e {
+                        SystemEvents::Transport {
+                            id: ev_id,
+                            event: TransportEvents::TransportDisabled,
+                        } if ev_id == transport_id => Some(()),
+                        _ => None,
+                    })
+                    .await
+                    {
+                        WaitResult::Matched(()) => {
+                            uplink_transport_enabled = false;
+                        }
+                        WaitResult::Timeout => {
+                            error!("FSM: timeout waiting for transport disable in SavingData");
+                        }
+                    }
+                }
+
                 let id = new_id();
                 info!(
                     "FSM: state=SavingData send SaveLocally id={} save_failures={}",

--- a/trailsense-edge/src/orchestration/types.rs
+++ b/trailsense-edge/src/orchestration/types.rs
@@ -19,6 +19,7 @@ pub enum SystemCmd {
     Connect { id: CorrelationId },
     UploadData { id: CorrelationId },
     SaveLocally { id: CorrelationId },
+    SetTransportEnabled { id: CorrelationId, enabled: bool },
     Sleep,
     Wake,
 }
@@ -37,6 +38,10 @@ pub enum SystemEvents {
         id: CorrelationId,
         event: DataEvents,
     },
+    Transport {
+        id: CorrelationId,
+        event: TransportEvents,
+    },
     InitComplete,
     Sleep(SleepEvents),
 }
@@ -46,6 +51,12 @@ pub enum SnifferEvents {
     StartedSniffing,
     SniffingError,
     StoppedSniffing,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum TransportEvents {
+    TransportEnabled,
+    TransportDisabled,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]

--- a/trailsense-edge/src/orchestration/types.rs
+++ b/trailsense-edge/src/orchestration/types.rs
@@ -1,3 +1,6 @@
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct CorrelationId(pub u32);
+
 #[derive(PartialEq, Eq)]
 pub enum SystemState {
     Idle,
@@ -11,21 +14,30 @@ pub enum SystemState {
 
 #[derive(PartialEq, Eq)]
 pub enum SystemCmd {
-    StartSniffing,
-    StopSniffing,
-    Connect,
-    UploadData,
-    SaveLocally,
+    StartSniffing { id: CorrelationId },
+    StopSniffing { id: CorrelationId },
+    Connect { id: CorrelationId },
+    UploadData { id: CorrelationId },
+    SaveLocally { id: CorrelationId },
     Sleep,
     Wake,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]
 pub enum SystemEvents {
+    Sniffer {
+        id: CorrelationId,
+        event: SnifferEvents,
+    },
+    Upload {
+        id: CorrelationId,
+        event: UploadEvents,
+    },
+    Data {
+        id: CorrelationId,
+        event: DataEvents,
+    },
     InitComplete,
-    Sniffer(SnifferEvents),
-    Upload(UploadEvents),
-    Data(DataEvents),
     Sleep(SleepEvents),
 }
 
@@ -41,7 +53,7 @@ pub enum UploadEvents {
     NetworkConnected,
     NetworkError,
     UploadError,
-    UploadSuccessfull,
+    UploadSuccessful,
 }
 
 #[derive(PartialEq, Eq, Debug, Clone)]

--- a/trailsense-edge/src/orchestration/types.rs
+++ b/trailsense-edge/src/orchestration/types.rs
@@ -1,0 +1,56 @@
+#[derive(PartialEq, Eq)]
+pub enum SystemState {
+    Idle,
+    Sniffing,
+    PreparingUpload,
+    Connecting,
+    Uploading,
+    SavingData,
+    Sleep,
+}
+
+#[derive(PartialEq, Eq)]
+pub enum SystemCmd {
+    StartSniffing,
+    StopSniffing,
+    Connect,
+    UploadData,
+    SaveLocally,
+    Sleep,
+    Wake,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum SystemEvents {
+    InitComplete,
+    Sniffer(SnifferEvents),
+    Upload(UploadEvents),
+    Data(DataEvents),
+    Sleep(SleepEvents),
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum SnifferEvents {
+    StartedSniffing,
+    SniffingError,
+    StoppedSniffing,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum UploadEvents {
+    NetworkConnected,
+    NetworkError,
+    UploadError,
+    UploadSuccessfull,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum DataEvents {
+    DataSaved,
+    DataError,
+}
+
+#[derive(PartialEq, Eq, Debug, Clone)]
+pub enum SleepEvents {
+    SleepFinished,
+}

--- a/trailsense-edge/src/probes/counter.rs
+++ b/trailsense-edge/src/probes/counter.rs
@@ -9,8 +9,9 @@ pub fn deduplicate_probes(input_fingerprints: &[u16]) -> u32 {
     let mut survivors: Vec<u16> = Vec::new();
     survivors.push(input_fingerprints[0]);
 
+    // Threshold needs to be lowered for now for testing reasons since it is very inaccurate. In future we should use 32 or 64 bit masks.
     for &fingerprint in &input_fingerprints[1..] {
-        if !is_duplicate(2, fingerprint, &survivors) {
+        if !is_duplicate(0, fingerprint, &survivors) {
             survivors.push(fingerprint);
         }
     }

--- a/trailsense-edge/src/probes/probe_parser.rs
+++ b/trailsense-edge/src/probes/probe_parser.rs
@@ -1,8 +1,9 @@
 extern crate alloc;
 use esp_radio::wifi::PromiscuousPkt;
 use ieee80211::{
-    GenericFrame,
-    common::{FrameType, ManagementFrameSubtype},
+    common::{FrameControlField, FrameType, ManagementFrameSubtype},
+    mgmt_frame::{ProbeRequestFrame, body::HasElements},
+    scroll::Pread,
 };
 use log::warn;
 
@@ -64,25 +65,28 @@ fn fingerprint_probe(data: &[u8]) -> u16 {
 }
 
 pub fn read_packet(packet: PromiscuousPkt<'_>) {
-    let Ok(frame) = GenericFrame::new(&packet.data, false) else {
+    if packet.data.len() < 2 {
+        return;
+    }
+
+    let fcf_bits = u16::from_le_bytes([packet.data[0], packet.data[1]]);
+    let fcf = FrameControlField::from_bits(fcf_bits);
+    if !matches!(
+        fcf.frame_type(),
+        FrameType::Management(ManagementFrameSubtype::ProbeRequest)
+    ) {
+        return;
+    }
+
+    let Ok(probe_req) = packet.data.pread_with::<ProbeRequestFrame>(0, false) else {
         return;
     };
 
-    if let Some(source) = frame.address_2() {
-        if !((source[0] == 84 && source[1] == 138 && source[2] == 186) // FOR TESTING PURPOSES: Filter out both CISCO and ESPRESSIF MAC-Addresses, to visualize "normal" devices
+    let source = probe_req.header.transmitter_address;
+    if !((source[0] == 84 && source[1] == 138 && source[2] == 186) // FOR TESTING PURPOSES: Filter out both CISCO and ESPRESSIF MAC-Addresses, to visualize "normal" devices
             || (source[0] == 52 && source[1] == 152 && source[2] == 122) || (source[0] == 112 && source[1] == 211 && source[2] == 121) || (source[0] == 16 && source[1] == 60 && source[2] == 89))
-        {
-            let fc = frame.frame_control_field();
-            if let FrameType::Management(subtype) = fc.frame_type() {
-                if subtype == ManagementFrameSubtype::ProbeRequest {
-                    let body_offset = 24;
-                    if packet.data.len() < body_offset {
-                        return;
-                    }
-                    let body = &packet.data[body_offset..];
-                    fingerprint_probe(body);
-                }
-            }
-        }
+    {
+        let elements = probe_req.body.get_elements();
+        fingerprint_probe(elements.bytes);
     }
 }

--- a/trailsense-edge/src/wifi/manager.rs
+++ b/trailsense-edge/src/wifi/manager.rs
@@ -20,7 +20,7 @@ pub async fn wifi_manager_task(
         SystemEvents,
         4,
         1,
-        2,
+        3,
     >,
 ) {
     loop {

--- a/trailsense-edge/src/wifi/manager.rs
+++ b/trailsense-edge/src/wifi/manager.rs
@@ -1,8 +1,11 @@
-use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::channel::Receiver;
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, pubsub::Publisher};
 
+use embassy_time::{Duration, Timer};
 use esp_radio::wifi::{PromiscuousPkt, Sniffer};
 use log::{error, info};
+
+use crate::orchestration::types::{SnifferEvents, SystemCmd, SystemEvents};
 
 #[derive(PartialEq)]
 pub enum WifiCmd {
@@ -11,31 +14,55 @@ pub enum WifiCmd {
     EnableSta,
 }
 
-// pub enum WifiEvt { Currently unused
-//     Online,
-//     Sniffing,
-// }
+const RADIO_SETTLE_DELAY: Duration = Duration::from_secs(5);
 
 #[embassy_executor::task]
 pub async fn wifi_manager_task(
     mut sniffer: Sniffer<'static>,
     callback: fn(PromiscuousPkt),
-    receiver: Receiver<'static, CriticalSectionRawMutex, WifiCmd, 4>,
+    sniffer_command_receiver: Receiver<'static, CriticalSectionRawMutex, SystemCmd, 4>,
+    orchestrator_event_publisher: Publisher<
+        'static,
+        CriticalSectionRawMutex,
+        SystemEvents,
+        4,
+        1,
+        2,
+    >,
 ) {
     loop {
-        let cmd = receiver.receive().await;
-        if cmd == WifiCmd::StartSniffing {
+        let command = sniffer_command_receiver.receive().await;
+        if command == SystemCmd::StartSniffing {
             match sniffer.set_promiscuous_mode(true) {
                 Ok(()) => {
                     info!("Enabled Promiscuous Mode");
                     sniffer.set_receive_cb(callback);
+                    orchestrator_event_publisher
+                        .publish(SystemEvents::Sniffer(SnifferEvents::StartedSniffing))
+                        .await;
                 }
-                Err(e) => error!("Failed to enable promiscuous mode: {:?}", e),
+                Err(e) => {
+                    error!("Failed to enable promiscuous mode: {:?}", e);
+                    orchestrator_event_publisher
+                        .publish(SystemEvents::Sniffer(SnifferEvents::SniffingError))
+                        .await;
+                }
             }
-        } else if cmd == WifiCmd::StopSniffing {
+        } else if command == SystemCmd::StopSniffing {
             match sniffer.set_promiscuous_mode(false) {
-                Ok(()) => info!("Disabled Promiscuous mode"),
-                Err(e) => error!("Failed to disable promiscuous mode: {:?}", e),
+                Ok(()) => {
+                    info!("Disabled Promiscuous mode");
+                    Timer::after(RADIO_SETTLE_DELAY).await;
+                    orchestrator_event_publisher
+                        .publish(SystemEvents::Sniffer(SnifferEvents::StoppedSniffing))
+                        .await;
+                }
+                Err(e) => {
+                    error!("Failed to disable promiscuous mode: {:?}", e);
+                    orchestrator_event_publisher
+                        .publish(SystemEvents::Sniffer(SnifferEvents::SniffingError))
+                        .await;
+                }
             }
         }
     }

--- a/trailsense-edge/src/wifi/manager.rs
+++ b/trailsense-edge/src/wifi/manager.rs
@@ -7,13 +7,6 @@ use log::{error, info};
 
 use crate::orchestration::types::{SnifferEvents, SystemCmd, SystemEvents};
 
-#[derive(PartialEq)]
-pub enum WifiCmd {
-    StartSniffing,
-    StopSniffing,
-    EnableSta,
-}
-
 const RADIO_SETTLE_DELAY: Duration = Duration::from_secs(5);
 
 #[embassy_executor::task]
@@ -32,37 +25,54 @@ pub async fn wifi_manager_task(
 ) {
     loop {
         let command = sniffer_command_receiver.receive().await;
-        if command == SystemCmd::StartSniffing {
-            match sniffer.set_promiscuous_mode(true) {
+
+        match command {
+            SystemCmd::StartSniffing { id } => match sniffer.set_promiscuous_mode(true) {
                 Ok(()) => {
                     info!("Enabled Promiscuous Mode");
                     sniffer.set_receive_cb(callback);
                     orchestrator_event_publisher
-                        .publish(SystemEvents::Sniffer(SnifferEvents::StartedSniffing))
+                        .publish(SystemEvents::Sniffer {
+                            id,
+                            event: SnifferEvents::StartedSniffing,
+                        })
                         .await;
                 }
                 Err(e) => {
                     error!("Failed to enable promiscuous mode: {:?}", e);
                     orchestrator_event_publisher
-                        .publish(SystemEvents::Sniffer(SnifferEvents::SniffingError))
+                        .publish(SystemEvents::Sniffer {
+                            id,
+                            event: SnifferEvents::SniffingError,
+                        })
                         .await;
                 }
-            }
-        } else if command == SystemCmd::StopSniffing {
-            match sniffer.set_promiscuous_mode(false) {
+            },
+
+            SystemCmd::StopSniffing { id } => match sniffer.set_promiscuous_mode(false) {
                 Ok(()) => {
                     info!("Disabled Promiscuous mode");
                     Timer::after(RADIO_SETTLE_DELAY).await;
                     orchestrator_event_publisher
-                        .publish(SystemEvents::Sniffer(SnifferEvents::StoppedSniffing))
+                        .publish(SystemEvents::Sniffer {
+                            id,
+                            event: SnifferEvents::StoppedSniffing,
+                        })
                         .await;
                 }
                 Err(e) => {
                     error!("Failed to disable promiscuous mode: {:?}", e);
                     orchestrator_event_publisher
-                        .publish(SystemEvents::Sniffer(SnifferEvents::SniffingError))
+                        .publish(SystemEvents::Sniffer {
+                            id,
+                            event: SnifferEvents::SniffingError,
+                        })
                         .await;
                 }
+            },
+
+            _ => {
+                // ignore commands not handled by wifi manager
             }
         }
     }

--- a/trailsense-edge/src/wifi/tasks.rs
+++ b/trailsense-edge/src/wifi/tasks.rs
@@ -1,8 +1,12 @@
 use embassy_net::Runner;
-use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Receiver};
+use embassy_sync::{
+    blocking_mutex::raw::CriticalSectionRawMutex, channel::Receiver, pubsub::Publisher,
+};
 use embassy_time::{Duration, Timer};
 use esp_radio::wifi::{ClientConfig, ModeConfig, WifiController, WifiDevice, WifiStaState};
 use log::{error, info};
+
+use crate::orchestration::types::{CorrelationId, SystemEvents, TransportEvents};
 
 const SSID: Option<&'static str> = option_env!("WIFI_SSID");
 const PASSWORD: Option<&'static str> = option_env!("WIFI_PASSWORD");
@@ -16,7 +20,7 @@ const CONNECT_FAILURE_RESTART_THRESHOLD: u8 = 6;
 pub enum WifiControlCmd {
     Reconnect,
     RestartController,
-    EnableAutoConnect(bool),
+    SetAutoConnect { enabled: bool, id: CorrelationId },
 }
 
 #[embassy_executor::task]
@@ -28,9 +32,19 @@ pub async fn net_task(mut runner: Runner<'static, WifiDevice<'static>>) {
 pub async fn connect(
     mut controller: WifiController<'static>,
     control_receiver: Receiver<'static, CriticalSectionRawMutex, WifiControlCmd, 4>,
+    orchestrator_event_publisher: Publisher<
+        'static,
+        CriticalSectionRawMutex,
+        SystemEvents,
+        4,
+        1,
+        3,
+    >,
 ) {
     let mut auto_connect_enabled = true;
+    let mut last_auto_connect_state = true;
     let mut consecutive_connect_failures: u8 = 0;
+    let mut pending_transport_ack: Option<(CorrelationId, bool)> = None;
 
     let ssid = match SSID {
         Some(v) => v,
@@ -51,46 +65,93 @@ pub async fn connect(
     info!("Connecting to wifi");
 
     loop {
+        let mut requested_reconnect = false;
+        let mut requested_restart = false;
+
         // Drain queued control commands first so state changes are applied promptly.
         while let Ok(cmd) = control_receiver.try_receive() {
             match cmd {
-                WifiControlCmd::EnableAutoConnect(enabled) => {
+                WifiControlCmd::SetAutoConnect { enabled, id } => {
                     auto_connect_enabled = enabled;
                     info!("WIFI: auto-connect set to {}", enabled);
                     consecutive_connect_failures = 0;
-
-                    if !enabled {
-                        // Optional: force disconnect when pausing.
-                        if let Err(e) = controller.disconnect_async().await {
-                            error!("WIFI: disconnect on pause failed: {:?}", e);
-                        }
-                    }
+                    pending_transport_ack = Some((id, enabled));
                 }
                 WifiControlCmd::Reconnect => {
                     info!("Wi-Fi reconnect requested");
                     consecutive_connect_failures = 0;
-                    if let Err(e) = controller.disconnect_async().await {
-                        error!("Failed to disconnect Wi-Fi during reconnect: {:?}", e);
-                    }
-                    Timer::after(RECONNECT_SETTLE_DELAY).await;
+                    requested_reconnect = true;
                 }
                 WifiControlCmd::RestartController => {
                     info!("Wi-Fi controller restart requested");
                     consecutive_connect_failures = 0;
-                    if let Err(e) = controller.disconnect_async().await {
-                        error!("Failed to disconnect Wi-Fi before restart: {:?}", e);
-                    }
-                    if let Err(e) = controller.stop_async().await {
-                        error!("Failed to stop Wi-Fi controller: {:?}", e);
-                    }
-                    Timer::after(RESTART_SETTLE_DELAY).await;
+                    requested_restart = true;
                 }
             }
         }
 
+        if last_auto_connect_state && !auto_connect_enabled {
+            let disconnect_ok = match controller.disconnect_async().await {
+                Ok(()) => true,
+                Err(e) => {
+                    error!("WIFI: disconnect on pause failed: {:?}", e);
+                    false
+                }
+            };
+
+            if disconnect_ok {
+                if let Some((id, enabled)) = pending_transport_ack {
+                    if !enabled {
+                        orchestrator_event_publisher
+                            .publish(SystemEvents::Transport {
+                                id,
+                                event: TransportEvents::TransportDisabled,
+                            })
+                            .await;
+
+                        pending_transport_ack = None;
+                    }
+                }
+            }
+        }
+
+        last_auto_connect_state = auto_connect_enabled;
+
         if !auto_connect_enabled {
-            consecutive_connect_failures = 0;
             Timer::after(WIFI_POLL_INTERVAL).await;
+            continue;
+        }
+
+        if auto_connect_enabled && let Some((id, enabled)) = pending_transport_ack {
+            if enabled {
+                orchestrator_event_publisher
+                    .publish(SystemEvents::Transport {
+                        id,
+                        event: TransportEvents::TransportEnabled,
+                    })
+                    .await;
+
+                pending_transport_ack = None;
+            }
+        }
+
+        // This is on top to give it priority over reconnect.
+        if requested_restart {
+            if let Err(e) = controller.disconnect_async().await {
+                error!("Failed to disconnect Wi-Fi before restart: {:?}", e);
+            }
+            if let Err(e) = controller.stop_async().await {
+                error!("Failed to stop Wi-Fi controller: {:?}", e);
+            }
+            Timer::after(RESTART_SETTLE_DELAY).await;
+            continue;
+        }
+
+        if requested_reconnect {
+            if let Err(e) = controller.disconnect_async().await {
+                error!("Failed to disconnect Wi-Fi during reconnect: {:?}", e);
+            }
+            Timer::after(RECONNECT_SETTLE_DELAY).await;
             continue;
         }
 

--- a/trailsense-edge/src/wifi/tasks.rs
+++ b/trailsense-edge/src/wifi/tasks.rs
@@ -93,7 +93,12 @@ pub async fn connect(
         match controller.connect_async().await {
             Ok(_) => info!("Wifi connected!"),
             Err(e) => {
-                error!("Failed to connect to wifi: {:?}", e);
+                error!(
+                    "WIFI: connect_async failed: {:?}, sta_state={:?}, started={:?}",
+                    e,
+                    esp_radio::wifi::sta_state(),
+                    controller.is_started()
+                );
                 Timer::after(WIFI_RETRY_DELAY).await;
             }
         }

--- a/trailsense-edge/src/wifi/tasks.rs
+++ b/trailsense-edge/src/wifi/tasks.rs
@@ -10,11 +10,13 @@ const WIFI_RETRY_DELAY: Duration = Duration::from_secs(5);
 const WIFI_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const RECONNECT_SETTLE_DELAY: Duration = Duration::from_secs(2);
 const RESTART_SETTLE_DELAY: Duration = Duration::from_secs(2);
+const CONNECT_FAILURE_RESTART_THRESHOLD: u8 = 6;
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum WifiControlCmd {
     Reconnect,
     RestartController,
+    EnableAutoConnect(bool),
 }
 
 #[embassy_executor::task]
@@ -27,6 +29,9 @@ pub async fn connect(
     mut controller: WifiController<'static>,
     control_receiver: Receiver<'static, CriticalSectionRawMutex, WifiControlCmd, 4>,
 ) {
+    let mut auto_connect_enabled = true;
+    let mut consecutive_connect_failures: u8 = 0;
+
     let ssid = match SSID {
         Some(v) => v,
         None => {
@@ -46,23 +51,47 @@ pub async fn connect(
     info!("Connecting to wifi");
 
     loop {
-        if let Ok(cmd) = control_receiver.try_receive() {
-            if cmd == WifiControlCmd::Reconnect {
-                info!("Wi-Fi reconnect requested");
-                if let Err(e) = controller.disconnect_async().await {
-                    error!("Failed to disconnect Wi-Fi during reconnect: {:?}", e);
+        // Drain queued control commands first so state changes are applied promptly.
+        while let Ok(cmd) = control_receiver.try_receive() {
+            match cmd {
+                WifiControlCmd::EnableAutoConnect(enabled) => {
+                    auto_connect_enabled = enabled;
+                    info!("WIFI: auto-connect set to {}", enabled);
+                    consecutive_connect_failures = 0;
+
+                    if !enabled {
+                        // Optional: force disconnect when pausing.
+                        if let Err(e) = controller.disconnect_async().await {
+                            error!("WIFI: disconnect on pause failed: {:?}", e);
+                        }
+                    }
                 }
-                Timer::after(RECONNECT_SETTLE_DELAY).await;
-            } else if cmd == WifiControlCmd::RestartController {
-                info!("Wi-Fi controller restart requested");
-                if let Err(e) = controller.disconnect_async().await {
-                    error!("Failed to disconnect Wi-Fi before restart: {:?}", e);
+                WifiControlCmd::Reconnect => {
+                    info!("Wi-Fi reconnect requested");
+                    consecutive_connect_failures = 0;
+                    if let Err(e) = controller.disconnect_async().await {
+                        error!("Failed to disconnect Wi-Fi during reconnect: {:?}", e);
+                    }
+                    Timer::after(RECONNECT_SETTLE_DELAY).await;
                 }
-                if let Err(e) = controller.stop_async().await {
-                    error!("Failed to stop Wi-Fi controller: {:?}", e);
+                WifiControlCmd::RestartController => {
+                    info!("Wi-Fi controller restart requested");
+                    consecutive_connect_failures = 0;
+                    if let Err(e) = controller.disconnect_async().await {
+                        error!("Failed to disconnect Wi-Fi before restart: {:?}", e);
+                    }
+                    if let Err(e) = controller.stop_async().await {
+                        error!("Failed to stop Wi-Fi controller: {:?}", e);
+                    }
+                    Timer::after(RESTART_SETTLE_DELAY).await;
                 }
-                Timer::after(RESTART_SETTLE_DELAY).await;
             }
+        }
+
+        if !auto_connect_enabled {
+            consecutive_connect_failures = 0;
+            Timer::after(WIFI_POLL_INTERVAL).await;
+            continue;
         }
 
         if matches!(esp_radio::wifi::sta_state(), WifiStaState::Connected) {
@@ -91,14 +120,39 @@ pub async fn connect(
         }
 
         match controller.connect_async().await {
-            Ok(_) => info!("Wifi connected!"),
+            Ok(_) => {
+                consecutive_connect_failures = 0;
+                info!("Wifi connected!");
+                Timer::after(WIFI_POLL_INTERVAL).await;
+            }
             Err(e) => {
+                consecutive_connect_failures = consecutive_connect_failures.saturating_add(1);
                 error!(
-                    "WIFI: connect_async failed: {:?}, sta_state={:?}, started={:?}",
+                    "WIFI: connect_async failed: {:?}, sta_state={:?}, started={:?}, failures={}",
                     e,
                     esp_radio::wifi::sta_state(),
-                    controller.is_started()
+                    controller.is_started(),
+                    consecutive_connect_failures
                 );
+
+                if consecutive_connect_failures >= CONNECT_FAILURE_RESTART_THRESHOLD {
+                    error!(
+                        "WIFI: too many connect failures ({}), restarting controller",
+                        consecutive_connect_failures
+                    );
+
+                    if let Err(err) = controller.disconnect_async().await {
+                        error!("WIFI: disconnect before auto-restart failed: {:?}", err);
+                    }
+                    if let Err(err) = controller.stop_async().await {
+                        error!("WIFI: stop during auto-restart failed: {:?}", err);
+                    }
+
+                    consecutive_connect_failures = 0;
+                    Timer::after(RESTART_SETTLE_DELAY).await;
+                    continue;
+                }
+
                 Timer::after(WIFI_RETRY_DELAY).await;
             }
         }


### PR DESCRIPTION
## Summary
Implemented a full event-driven orchestration flow for the edge node and finalized the behavior according to the intended architecture, even though it differs from the original ticket plan. The PR introduces a dedicated orchestrator-based state machine and integrates command/event coordination across sniffing, transport control, upload, and local fallback handling.

## Changes

### Main Changes:
- Added a dedicated orchestrator task to centralize runtime control flow as a finite state machine.
- Defined and used correlation-id-based command/event handshakes to make async transitions deterministic.
- Implemented state transitions for idle, sniffing, preparing upload, connecting, uploading, local saving fallback, and sleep.
- Added guarded transport enable/disable sequencing around sniffing and upload phases.
- Introduced timeout-aware event waiting with absolute deadline logic (prevents timeout extension from unrelated events).
- Integrated local fallback handling via `SaveLocally` command/event flow so fallback no longer relies on implicit timeouts.
- Finalized implementation details based on desired end behavior rather than strictly following the initial ticket sequence.

### Fixes (Optional):
- Fixed a transition sequencing issue in `PreparingUpload` so connect flow only starts after transport enable is acknowledged.
- Fixed potential indefinite wait behavior by replacing rolling timeouts with deadline-based waiting.
- Fixed missing local-save response path by ensuring `DataSaved` / `DataError` events are published for fallback handling.
- Corrected state-machine observability issues (correlation/log consistency improvements).

### Special Functions:
- `orchestrate_node`: Added/expanded as the central FSM coordinator for subsystem commands and event-driven transitions.
- `wait_for`: Updated to deadline-based timeout behavior to avoid starvation under noisy pubsub traffic.
- `uploader_task`: Extended to handle `SaveLocally` command path and publish data events expected by the orchestrator.