### PR TITLE
Gsm Recovery Readiness and Hardware Reset

### DIFF
--- a/trailsense-edge/src/bin/main.rs
+++ b/trailsense-edge/src/bin/main.rs
@@ -105,9 +105,8 @@ async fn main(spawner: Spawner) -> ! {
     #[cfg(feature = "uplink-gsm")]
     let transport = match build_active_transport_gsm(uart, spawner) {
         Ok(t) => t,
-        // TODO: (hw-reset): wire ESP32 GPIO to modem RESET/PWRKEY and attempt hardware reset + reinit before fatal_idle().
         Err(e) => {
-            error!("Issue initializing GSM module (fatal): {:?}", e);
+            error!("Issue initializing GSM module: {:?}", e);
             fatal_idle().await;
         }
     };

--- a/trailsense-edge/src/hardware/gsm_reset.rs
+++ b/trailsense-edge/src/hardware/gsm_reset.rs
@@ -1,0 +1,80 @@
+use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, channel::Receiver};
+use embassy_time::{Duration, Timer};
+use esp_hal::gpio::{Flex, InputConfig, OutputConfig};
+use log::info;
+
+use crate::hardware::types::HardwareCmd;
+
+#[cfg(feature = "uplink-gsm")]
+const FORCE_POWER_DOWN_ASSERT_SECS: u64 = 16;
+#[cfg(feature = "uplink-gsm")]
+const POWER_DOWN_SETTLE_SECS: u64 = 2;
+#[cfg(feature = "uplink-gsm")]
+const POWER_ON_TAP_SECS: u64 = 2;
+#[cfg(feature = "uplink-gsm")]
+const POWER_ON_SETTLE_SECS: u64 = 5;
+
+#[cfg(feature = "uplink-gsm")]
+fn drive_pwrkey_low(pin: &mut Flex<'_>) {
+    pin.apply_output_config(&OutputConfig::default());
+    pin.set_input_enable(false);
+    pin.set_low();
+    pin.set_output_enable(true);
+}
+
+#[cfg(feature = "uplink-gsm")]
+fn release_pwrkey_high_z(pin: &mut Flex<'_>) {
+    pin.set_output_enable(false);
+    pin.apply_input_config(&InputConfig::default());
+    pin.set_input_enable(true);
+}
+
+// This is test code for power reset. Does not work for our breakout model. But it could work if we build our custom pcb. It is not included in build
+#[cfg(feature = "uplink-gsm")]
+pub async fn pulse_gsm_reset_pin(gsm_reset_pin: &mut Flex<'_>) {
+    // A7670E force reboot via PWRKEY:
+    // 1) Hold LOW long enough to force power down
+    // 2) Release to high-Z and wait for full power-down
+    // 3) Hold LOW briefly to power back on
+    // 4) Release to high-Z and wait for boot
+    info!(
+        "GSM reset: force power down (hold LOW {}s)",
+        FORCE_POWER_DOWN_ASSERT_SECS
+    );
+    drive_pwrkey_low(gsm_reset_pin);
+    Timer::after(Duration::from_secs(FORCE_POWER_DOWN_ASSERT_SECS)).await;
+
+    info!(
+        "GSM reset: release PWRKEY, settling {}s",
+        POWER_DOWN_SETTLE_SECS
+    );
+    release_pwrkey_high_z(gsm_reset_pin);
+    Timer::after(Duration::from_secs(POWER_DOWN_SETTLE_SECS)).await;
+
+    info!("GSM reset: power on tap (hold LOW {}s)", POWER_ON_TAP_SECS);
+    drive_pwrkey_low(gsm_reset_pin);
+    Timer::after(Duration::from_secs(POWER_ON_TAP_SECS)).await;
+
+    release_pwrkey_high_z(gsm_reset_pin);
+    info!(
+        "GSM reset: sequence complete, boot settle {}s",
+        POWER_ON_SETTLE_SECS
+    );
+    Timer::after(Duration::from_secs(POWER_ON_SETTLE_SECS)).await;
+}
+
+#[cfg(feature = "uplink-gsm")]
+#[embassy_executor::task]
+pub async fn trigger_gsm_reset(
+    mut gsm_reset_pin: Flex<'static>,
+    hardware_receiver: Receiver<'static, CriticalSectionRawMutex, HardwareCmd, 4>,
+) -> ! {
+    loop {
+        let command = hardware_receiver.receive().await;
+        match command {
+            HardwareCmd::ResetGSM => {
+                pulse_gsm_reset_pin(&mut gsm_reset_pin).await;
+            }
+        }
+    }
+}

--- a/trailsense-edge/src/hardware/gsm_reset.rs
+++ b/trailsense-edge/src/hardware/gsm_reset.rs
@@ -5,16 +5,11 @@ use log::info;
 
 use crate::hardware::types::HardwareCmd;
 
-#[cfg(feature = "uplink-gsm")]
 const FORCE_POWER_DOWN_ASSERT_SECS: u64 = 16;
-#[cfg(feature = "uplink-gsm")]
 const POWER_DOWN_SETTLE_SECS: u64 = 2;
-#[cfg(feature = "uplink-gsm")]
 const POWER_ON_TAP_SECS: u64 = 2;
-#[cfg(feature = "uplink-gsm")]
 const POWER_ON_SETTLE_SECS: u64 = 5;
 
-#[cfg(feature = "uplink-gsm")]
 fn drive_pwrkey_low(pin: &mut Flex<'_>) {
     pin.apply_output_config(&OutputConfig::default());
     pin.set_input_enable(false);
@@ -22,15 +17,15 @@ fn drive_pwrkey_low(pin: &mut Flex<'_>) {
     pin.set_output_enable(true);
 }
 
-#[cfg(feature = "uplink-gsm")]
 fn release_pwrkey_high_z(pin: &mut Flex<'_>) {
     pin.set_output_enable(false);
     pin.apply_input_config(&InputConfig::default());
     pin.set_input_enable(true);
 }
 
-// This is test code for power reset. Does not work for our breakout model. But it could work if we build our custom pcb. It is not included in build
-#[cfg(feature = "uplink-gsm")]
+// Test code for GSM power reset. It does not work with our current breakout model,
+// but it may be useful for a custom PCB. This code is currently unwired in
+// the build.
 pub async fn pulse_gsm_reset_pin(gsm_reset_pin: &mut Flex<'_>) {
     // A7670E force reboot via PWRKEY:
     // 1) Hold LOW long enough to force power down
@@ -63,7 +58,6 @@ pub async fn pulse_gsm_reset_pin(gsm_reset_pin: &mut Flex<'_>) {
     Timer::after(Duration::from_secs(POWER_ON_SETTLE_SECS)).await;
 }
 
-#[cfg(feature = "uplink-gsm")]
 #[embassy_executor::task]
 pub async fn trigger_gsm_reset(
     mut gsm_reset_pin: Flex<'static>,

--- a/trailsense-edge/src/hardware/mod.rs
+++ b/trailsense-edge/src/hardware/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(feature = "uplink-gsm")]
+pub mod gsm_reset;
+#[cfg(feature = "uplink-gsm")]
+pub mod types;
+// Placeholder hardware module for future GSM sleep/wake control.

--- a/trailsense-edge/src/hardware/types.rs
+++ b/trailsense-edge/src/hardware/types.rs
@@ -1,0 +1,4 @@
+#[derive(PartialEq, Eq)]
+pub enum HardwareCmd {
+    ResetGSM,
+}

--- a/trailsense-edge/src/lib.rs
+++ b/trailsense-edge/src/lib.rs
@@ -6,7 +6,6 @@ compile_error!("Features `uplink-wifi` and `uplink-gsm` are mutually exclusive. 
 #[cfg(not(any(feature = "uplink-wifi", feature = "uplink-gsm")))]
 compile_error!("No uplink transport selected. Enable `uplink-gsm` (default) or `uplink-wifi`.");
 
-
 // TODO: This has been deactiveated since not needed for now. Could be needed for sleep etc.
 // #[cfg(feature = "uplink-gsm")]
 // pub mod hardware;

--- a/trailsense-edge/src/lib.rs
+++ b/trailsense-edge/src/lib.rs
@@ -6,7 +6,7 @@ compile_error!("Features `uplink-wifi` and `uplink-gsm` are mutually exclusive. 
 #[cfg(not(any(feature = "uplink-wifi", feature = "uplink-gsm")))]
 compile_error!("No uplink transport selected. Enable `uplink-gsm` (default) or `uplink-wifi`.");
 
-// TODO: This has been deactiveated since not needed for now. Could be needed for sleep etc.
+// TODO: This has been deactivated/unwired since not needed for now. Could be needed for sleep etc.
 // #[cfg(feature = "uplink-gsm")]
 // pub mod hardware;
 pub mod network;

--- a/trailsense-edge/src/lib.rs
+++ b/trailsense-edge/src/lib.rs
@@ -6,6 +6,10 @@ compile_error!("Features `uplink-wifi` and `uplink-gsm` are mutually exclusive. 
 #[cfg(not(any(feature = "uplink-wifi", feature = "uplink-gsm")))]
 compile_error!("No uplink transport selected. Enable `uplink-gsm` (default) or `uplink-wifi`.");
 
+
+// TODO: This has been deactiveated since not needed for now. Could be needed for sleep etc.
+// #[cfg(feature = "uplink-gsm")]
+// pub mod hardware;
 pub mod network;
 pub mod orchestration;
 pub mod packages;

--- a/trailsense-edge/src/network/gsm/commands.rs
+++ b/trailsense-edge/src/network/gsm/commands.rs
@@ -169,6 +169,7 @@ impl Parser for HttpUrcParser {
 pub enum GsmError {
     Atat(AtatError),
     IpTimeout,
+    NotReady,
     BufferTooSmall { needed: usize, available: usize },
     CommandBuildFailed,
     HttpActionTimeout,
@@ -186,6 +187,7 @@ impl GsmError {
     pub fn kind(&self) -> GsmErrorKind {
         match self {
             GsmError::IpTimeout => GsmErrorKind::Transient,
+            GsmError::NotReady => GsmErrorKind::Transient,
             GsmError::BufferTooSmall { .. } => GsmErrorKind::Hard,
             GsmError::CommandBuildFailed => GsmErrorKind::Hard,
             GsmError::HttpActionTimeout => GsmErrorKind::Transient,

--- a/trailsense-edge/src/network/gsm/helpers.rs
+++ b/trailsense-edge/src/network/gsm/helpers.rs
@@ -3,8 +3,8 @@ use esp_hal::uart::UartTx;
 
 use crate::network::gsm::commands::{GsmError, RawAtCmd, RawAtReadCmd, RawPayload};
 
-const RAW_CMD_TIMEOUT_MS: u32 = 20_000;
-const RAW_PAYLOAD_TIMEOUT_MS: u32 = 20_000;
+pub const DEFAULT_RAW_CMD_TIMEOUT_MS: u32 = 20_000;
+pub const DEFAULT_RAW_PAYLOAD_TIMEOUT_MS: u32 = 20_000;
 
 // INGRESS_BUF_SIZE was used as our maximum size of messages. To increase the size, we should test it and see, but only if needed
 async fn send_raw_cmd_inner<const INGRESS_BUF_SIZE: usize, const TIMEOUT_MS: u32>(
@@ -23,11 +23,11 @@ async fn send_raw_cmd_inner<const INGRESS_BUF_SIZE: usize, const TIMEOUT_MS: u32
     Ok(())
 }
 
-pub async fn send_raw_cmd<const INGRESS_BUF_SIZE: usize>(
+pub async fn send_raw_cmd<const INGRESS_BUF_SIZE: usize, const TIMEOUT_MS: u32>(
     client: &mut Client<'_, UartTx<'_, esp_hal::Async>, INGRESS_BUF_SIZE>,
     cmd: &str,
 ) -> Result<(), GsmError> {
-    send_raw_cmd_inner::<INGRESS_BUF_SIZE, RAW_CMD_TIMEOUT_MS>(client, cmd).await
+    send_raw_cmd_inner::<INGRESS_BUF_SIZE, TIMEOUT_MS>(client, cmd).await
 }
 
 pub async fn send_raw_payload<const INGRESS_BUF_SIZE: usize>(
@@ -41,12 +41,19 @@ pub async fn send_raw_payload<const INGRESS_BUF_SIZE: usize>(
             available: INGRESS_BUF_SIZE,
         });
     }
-    let raw = RawPayload::<INGRESS_BUF_SIZE, RAW_PAYLOAD_TIMEOUT_MS>::new(payload);
+    let raw = RawPayload::<INGRESS_BUF_SIZE, DEFAULT_RAW_PAYLOAD_TIMEOUT_MS>::new(payload);
     client.send(&raw).await.map_err(GsmError::from)?;
     Ok(())
 }
 
-pub async fn send_raw_read_cmd<const INGRESS_BUF_SIZE: usize>(
+pub async fn send_raw_read_cmd<const INGRESS_BUF_SIZE: usize, const TIMEOUT_MS: u32>(
+    client: &mut Client<'_, UartTx<'_, esp_hal::Async>, INGRESS_BUF_SIZE>,
+    cmd: &str,
+) -> Result<atat::heapless::String<512>, GsmError> {
+    send_raw_read_cmd_inner::<INGRESS_BUF_SIZE, TIMEOUT_MS>(client, cmd).await
+}
+
+async fn send_raw_read_cmd_inner<const INGRESS_BUF_SIZE: usize, const TIMEOUT_MS: u32>(
     client: &mut Client<'_, UartTx<'_, esp_hal::Async>, INGRESS_BUF_SIZE>,
     cmd: &str,
 ) -> Result<atat::heapless::String<512>, GsmError> {
@@ -57,6 +64,6 @@ pub async fn send_raw_read_cmd<const INGRESS_BUF_SIZE: usize>(
             available: INGRESS_BUF_SIZE,
         });
     }
-    let raw = RawAtReadCmd::<INGRESS_BUF_SIZE, RAW_CMD_TIMEOUT_MS>::new(cmd);
+    let raw = RawAtReadCmd::<INGRESS_BUF_SIZE, TIMEOUT_MS>::new(cmd);
     client.send(&raw).await.map_err(GsmError::from)
 }

--- a/trailsense-edge/src/network/gsm/modem.rs
+++ b/trailsense-edge/src/network/gsm/modem.rs
@@ -13,7 +13,7 @@ use esp_hal::{
     Async,
     uart::{Uart, UartRx},
 };
-use log::{error, info};
+use log::{debug, error, info};
 use static_cell::StaticCell;
 
 use crate::network::gsm::{
@@ -238,6 +238,10 @@ impl GsmModem {
             }
         }
         self.modem_ready = false;
+        error!(
+            "GSM readiness checks failed after {} attempts",
+            MAX_MODEM_READY_RETRIES
+        );
         return Err(GsmError::NotReady);
     }
 
@@ -253,8 +257,8 @@ impl GsmModem {
                 return Ok(());
             }
         }
-        error!(
-            "SIM not ready, command: {} response: {}",
+        debug!(
+            "GSM readiness probe not ready yet, command: {} response: {}",
             cmd,
             resp.as_str()
         );

--- a/trailsense-edge/src/network/gsm/modem.rs
+++ b/trailsense-edge/src/network/gsm/modem.rs
@@ -9,19 +9,25 @@ use core::{
     sync::atomic::{AtomicBool, Ordering},
 };
 use embassy_executor::Spawner;
-use esp_hal::{Async, uart::Uart, uart::UartRx};
+use esp_hal::{
+    Async,
+    uart::{Uart, UartRx},
+};
 use log::{error, info};
 use static_cell::StaticCell;
 
 use crate::network::gsm::{
     commands::{GetIpAddr, GsmError, GsmErrorKind, HttpUrcParser, NetOpen, Urc},
-    helpers::{send_raw_cmd, send_raw_payload, send_raw_read_cmd},
+    helpers::{
+        DEFAULT_RAW_CMD_TIMEOUT_MS, send_raw_cmd, send_raw_payload, send_raw_read_cmd,
+    },
 };
 
 pub struct GsmModem {
     client: Client<'static, esp_hal::uart::UartTx<'static, esp_hal::Async>, BUF_SIZE>,
     urc_sub: UrcSubscription<'static, Urc, URC_CAPACITY, URC_SUBSCRIBERS>,
     network_open_confirmed: bool,
+    modem_ready: bool,
 }
 pub const BUF_SIZE: usize = 1024;
 const URC_CAPACITY: usize = 1;
@@ -29,10 +35,15 @@ const URC_SUBSCRIBERS: usize = 1;
 const MAX_IP_RETRIES: usize = 5;
 const IP_RETRY_DELAY: u64 = 1;
 const MAX_CONNECT_RETRIES: usize = 3;
+const MAX_MODEM_READY_RETRIES: usize = 3;
 const CONNECT_RETRY_DELAY: u64 = 2;
 const HTTP_POST_ATTEMPTS: usize = 1;
 const HTTP_ACTION_TIMEOUT_SECS: u64 = 15;
 const HTTP_DATA_INPUT_TIMEOUT_MS: u32 = 5_000;
+const MODEM_INIT_ATTEMPT_DELAY_SECS: u64 = 2;
+const READY_AT_TIMEOUT_MS: u32 = 1_000;
+const READY_READ_TIMEOUT_MS: u32 = 3_000;
+
 static MODEM_IN_USE: AtomicBool = AtomicBool::new(false);
 
 impl GsmModem {
@@ -81,6 +92,7 @@ impl GsmModem {
             client,
             urc_sub,
             network_open_confirmed: false,
+            modem_ready: false,
         })
     }
     pub async fn open_network(&mut self) -> Result<(), GsmError> {
@@ -114,6 +126,11 @@ impl GsmModem {
         Err(GsmError::IpTimeout)
     }
     pub async fn ensure_connected(&mut self) -> Result<(), GsmError> {
+        if !self.modem_ready {
+            self.ensure_modem_ready().await?;
+            self.modem_ready = true;
+        }
+
         let mut last_err: Option<GsmError> = None;
 
         for _attempt in 0..MAX_CONNECT_RETRIES {
@@ -146,6 +163,7 @@ impl GsmModem {
                 }
                 Err(e) => {
                     if e.kind() == GsmErrorKind::Hard {
+                        self.modem_ready = false;
                         last_err = Some(e);
                         break;
                     }
@@ -161,6 +179,80 @@ impl GsmModem {
 
         Err(GsmError::IpTimeout)
     }
+    async fn ensure_modem_ready(&mut self) -> Result<(), GsmError> {
+        for _attempt in 0..MAX_MODEM_READY_RETRIES {
+            if let Err(e) =
+                send_raw_cmd::<BUF_SIZE, READY_AT_TIMEOUT_MS>(&mut self.client, "AT").await
+            {
+                info!("GSM: AT probe failed: {:?}", e);
+                embassy_time::Timer::after_secs(MODEM_INIT_ATTEMPT_DELAY_SECS).await;
+                continue;
+            }
+
+            match self
+                .expect_read_contains::<READY_READ_TIMEOUT_MS>("AT+CPIN?", &["READY"])
+                .await
+            {
+                Ok(_) => {
+                    info!("GSM: AT+CPIN is ready");
+                }
+                Err(_) => {
+                    embassy_time::Timer::after_secs(MODEM_INIT_ATTEMPT_DELAY_SECS).await;
+                    continue;
+                }
+            }
+
+            match self
+                .expect_read_contains::<READY_READ_TIMEOUT_MS>("AT+CEREG?", &[",1", ",5"])
+                .await
+            {
+                Ok(_) => {
+                    info!("GSM: AT+CEREG is ready");
+                }
+                Err(_) => {
+                    embassy_time::Timer::after_secs(MODEM_INIT_ATTEMPT_DELAY_SECS).await;
+                    continue;
+                }
+            }
+
+            match self
+                .expect_read_contains::<READY_READ_TIMEOUT_MS>("AT+CGATT?", &[": 1"])
+                .await
+            {
+                Ok(_) => {
+                    info!("GSM: AT+CGATT is ready");
+                    return Ok(());
+                }
+                Err(_) => {
+                    embassy_time::Timer::after_secs(MODEM_INIT_ATTEMPT_DELAY_SECS).await;
+                    continue;
+                }
+            }
+        }
+        self.modem_ready = false;
+        return Err(GsmError::NotReady);
+    }
+
+    async fn expect_read_contains<const TIMEOUT_MS: u32>(
+        &mut self,
+        cmd: &str,
+        expected_response: &[&str],
+    ) -> Result<(), GsmError> {
+        let resp = send_raw_read_cmd::<BUF_SIZE, TIMEOUT_MS>(&mut self.client, cmd).await?;
+
+        for response in expected_response.into_iter() {
+            if resp.as_str().contains(response) {
+                return Ok(());
+            }
+        }
+        error!(
+            "SIM not ready, command: {} response: {}",
+            cmd,
+            resp.as_str()
+        );
+        Err(GsmError::NotReady)
+    }
+
     pub async fn post_json(&mut self, payload: &str, url: &str) -> Result<(), GsmError> {
         let mut last_err: Option<GsmError> = None;
 
@@ -193,12 +285,16 @@ impl GsmModem {
         const DISCONNECT_IP_CHECK_RETRIES: usize = 3;
         const DISCONNECT_IP_CHECK_DELAY: u64 = 1;
 
-        let http_term_res = send_raw_cmd(&mut self.client, "AT+HTTPTERM").await;
+        let http_term_res =
+            send_raw_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(&mut self.client, "AT+HTTPTERM")
+                .await;
         if let Err(e) = &http_term_res {
             info!("GSM HTTPTERM returned: {:?}", e);
         }
 
-        let net_close_res = send_raw_cmd(&mut self.client, "AT+NETCLOSE").await;
+        let net_close_res =
+            send_raw_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(&mut self.client, "AT+NETCLOSE")
+                .await;
         if let Err(e) = &net_close_res {
             error!("GSM NETCLOSE failed: {:?}", e);
         } else {
@@ -240,7 +336,9 @@ impl GsmModem {
 impl GsmModem {
     async fn run_http_post_session(&mut self, payload: &str, url: &str) -> Result<(), GsmError> {
         info!("GSM HTTP step: HTTPTERM");
-        let _ = send_raw_cmd(&mut self.client, "AT+HTTPTERM").await;
+        let _ =
+            send_raw_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(&mut self.client, "AT+HTTPTERM")
+                .await;
 
         run_http_step(&mut self.client, "HTTPINIT", "AT+HTTPINIT").await?;
         run_http_step(
@@ -333,10 +431,18 @@ impl GsmModem {
         }
 
         info!("GSM HTTP step: HTTPREAD");
-        if let Ok(body) = send_raw_read_cmd(&mut self.client, "AT+HTTPREAD=0,512").await {
+        if let Ok(body) =
+            send_raw_read_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(
+                &mut self.client,
+                "AT+HTTPREAD=0,512",
+            )
+            .await
+        {
             info!("HTTPREAD body: {}", body);
         }
-        let _ = send_raw_cmd(&mut self.client, "AT+HTTPTERM").await;
+        let _ =
+            send_raw_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(&mut self.client, "AT+HTTPTERM")
+                .await;
         Ok(())
     }
 }
@@ -347,7 +453,7 @@ async fn run_http_step(
     cmd: &str,
 ) -> Result<(), GsmError> {
     info!("GSM HTTP step: {}", label);
-    if let Err(e) = send_raw_cmd(client, cmd).await {
+    if let Err(e) = send_raw_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(client, cmd).await {
         error!("GSM HTTP step failed: {}: {:?}", label, e);
         return Err(e);
     }
@@ -358,13 +464,15 @@ async fn log_http_action_timeout_diagnostics(
     client: &mut Client<'_, esp_hal::uart::UartTx<'_, esp_hal::Async>, BUF_SIZE>,
 ) {
     info!("GSM HTTP timeout diagnostics: HTTPREAD");
-    match send_raw_read_cmd(client, "AT+HTTPREAD=0,512").await {
+    match send_raw_read_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(client, "AT+HTTPREAD=0,512")
+        .await
+    {
         Ok(body) => info!("GSM HTTP timeout diagnostics HTTPREAD body: {}", body),
         Err(e) => info!("GSM HTTP timeout diagnostics HTTPREAD failed: {:?}", e),
     }
 
     info!("GSM HTTP timeout diagnostics: HTTPTERM");
-    match send_raw_cmd(client, "AT+HTTPTERM").await {
+    match send_raw_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(client, "AT+HTTPTERM").await {
         Ok(()) => info!("GSM HTTP timeout diagnostics HTTPTERM ok"),
         Err(e) => info!("GSM HTTP timeout diagnostics HTTPTERM failed: {:?}", e),
     }

--- a/trailsense-edge/src/network/gsm/modem.rs
+++ b/trailsense-edge/src/network/gsm/modem.rs
@@ -18,9 +18,7 @@ use static_cell::StaticCell;
 
 use crate::network::gsm::{
     commands::{GetIpAddr, GsmError, GsmErrorKind, HttpUrcParser, NetOpen, Urc},
-    helpers::{
-        DEFAULT_RAW_CMD_TIMEOUT_MS, send_raw_cmd, send_raw_payload, send_raw_read_cmd,
-    },
+    helpers::{DEFAULT_RAW_CMD_TIMEOUT_MS, send_raw_cmd, send_raw_payload, send_raw_read_cmd},
 };
 
 pub struct GsmModem {
@@ -28,6 +26,8 @@ pub struct GsmModem {
     urc_sub: UrcSubscription<'static, Urc, URC_CAPACITY, URC_SUBSCRIBERS>,
     network_open_confirmed: bool,
     modem_ready: bool,
+    connect_failure_streak: u8,
+    upload_failure_streak: u8,
 }
 pub const BUF_SIZE: usize = 1024;
 const URC_CAPACITY: usize = 1;
@@ -43,6 +43,9 @@ const HTTP_DATA_INPUT_TIMEOUT_MS: u32 = 5_000;
 const MODEM_INIT_ATTEMPT_DELAY_SECS: u64 = 2;
 const READY_AT_TIMEOUT_MS: u32 = 1_000;
 const READY_READ_TIMEOUT_MS: u32 = 3_000;
+const RECOVERY_INTER_STEP_DELAY_SECS: u64 = 2;
+const CPOWD_BOOT_SETTLE_SECS: u64 = 8;
+const UPLOAD_RECOVERY_THRESHOLD: u8 = 3;
 
 static MODEM_IN_USE: AtomicBool = AtomicBool::new(false);
 
@@ -93,6 +96,8 @@ impl GsmModem {
             urc_sub,
             network_open_confirmed: false,
             modem_ready: false,
+            connect_failure_streak: 0,
+            upload_failure_streak: 0,
         })
     }
     pub async fn open_network(&mut self) -> Result<(), GsmError> {
@@ -127,7 +132,10 @@ impl GsmModem {
     }
     pub async fn ensure_connected(&mut self) -> Result<(), GsmError> {
         if !self.modem_ready {
-            self.ensure_modem_ready().await?;
+            if let Err(e) = self.ensure_modem_ready().await {
+                self.handle_connect_failure_recovery().await;
+                return Err(e);
+            }
             self.modem_ready = true;
         }
 
@@ -138,6 +146,7 @@ impl GsmModem {
                 match self.client.send(&GetIpAddr).await {
                     Ok(resp) if !resp.ip.is_empty() && resp.ip != "0.0.0.0" => {
                         info!("Already connected; IP address: '{}'", resp.ip);
+                        self.connect_failure_streak = 0;
                         return Ok(());
                     }
                     Ok(resp) => {
@@ -158,6 +167,7 @@ impl GsmModem {
             match self.wait_for_ip().await {
                 Ok(()) => {
                     self.network_open_confirmed = true;
+                    self.connect_failure_streak = 0;
                     info!("Connected after NETOPEN + IP wait");
                     return Ok(());
                 }
@@ -173,11 +183,9 @@ impl GsmModem {
             }
         }
 
-        if let Some(e) = last_err {
-            return Err(e);
-        }
-
-        Err(GsmError::IpTimeout)
+        let err = last_err.unwrap_or(GsmError::IpTimeout);
+        self.handle_connect_failure_recovery().await;
+        Err(err)
     }
     async fn ensure_modem_ready(&mut self) -> Result<(), GsmError> {
         for _attempt in 0..MAX_MODEM_READY_RETRIES {
@@ -253,6 +261,70 @@ impl GsmModem {
         Err(GsmError::NotReady)
     }
 
+    async fn handle_connect_failure_recovery(&mut self) {
+        self.connect_failure_streak = self.connect_failure_streak.saturating_add(1);
+        let stage = (self.connect_failure_streak - 1) % 3;
+        info!(
+            "GSM recovery: streak={} -> stage={}",
+            self.connect_failure_streak,
+            stage + 1
+        );
+        self.run_recovery_stage(stage).await;
+
+        self.network_open_confirmed = false;
+        self.modem_ready = false;
+    }
+
+    async fn run_recovery_stage(&mut self, stage: u8) {
+        match stage {
+            0 => {
+                info!("GSM recovery L1: restarting radio stack with CFUN cycle");
+                if let Err(e) = send_raw_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(
+                    &mut self.client,
+                    "AT+CFUN=0",
+                )
+                .await
+                {
+                    info!("GSM recovery L1 CFUN=0 returned: {:?}", e);
+                }
+                embassy_time::Timer::after_secs(RECOVERY_INTER_STEP_DELAY_SECS).await;
+                if let Err(e) = send_raw_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(
+                    &mut self.client,
+                    "AT+CFUN=1",
+                )
+                .await
+                {
+                    info!("GSM recovery L1 CFUN=1 returned: {:?}", e);
+                }
+            }
+            1 => {
+                info!("GSM recovery L2: soft reboot with AT+CRESET");
+                if let Err(e) = send_raw_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(
+                    &mut self.client,
+                    "AT+CRESET",
+                )
+                .await
+                {
+                    info!("GSM recovery L2 CRESET returned: {:?}", e);
+                }
+                embassy_time::Timer::after_secs(RECOVERY_INTER_STEP_DELAY_SECS).await;
+            }
+            _ => {
+                info!("GSM recovery L3: power cycle with AT+CPOWD=1");
+                if let Err(e) = send_raw_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(
+                    &mut self.client,
+                    "AT+CPOWD=1",
+                )
+                .await
+                {
+                    // CPOWD may terminate UART path mid-command; treat failure here as expected.
+                    info!("GSM recovery L3 CPOWD returned: {:?}", e);
+                }
+                embassy_time::Timer::after_secs(CPOWD_BOOT_SETTLE_SECS).await;
+            }
+        }
+    }
+
     pub async fn post_json(&mut self, payload: &str, url: &str) -> Result<(), GsmError> {
         let mut last_err: Option<GsmError> = None;
 
@@ -261,6 +333,7 @@ impl GsmModem {
 
             match self.run_http_post_session(payload, url).await {
                 Ok(()) => {
+                    self.upload_failure_streak = 0;
                     info!("GSM HTTP upload completed");
                     return Ok(());
                 }
@@ -273,12 +346,36 @@ impl GsmModem {
                         );
                     }
                     error!("GSM HTTP session attempt={} failed: {:?}", attempt, e);
+                    self.handle_upload_failure_recovery(e.kind()).await;
                     last_err = Some(e);
                 }
             }
         }
 
         Err(last_err.unwrap_or(GsmError::HttpActionTimeout))
+    }
+
+    async fn handle_upload_failure_recovery(&mut self, kind: GsmErrorKind) {
+        if kind == GsmErrorKind::Hard {
+            self.upload_failure_streak = 0;
+            return;
+        }
+
+        self.upload_failure_streak = self.upload_failure_streak.saturating_add(1);
+        if self.upload_failure_streak < UPLOAD_RECOVERY_THRESHOLD {
+            return;
+        }
+
+        let stage = (self.upload_failure_streak - UPLOAD_RECOVERY_THRESHOLD) % 3;
+        info!(
+            "GSM upload recovery: streak={} -> stage={}",
+            self.upload_failure_streak,
+            stage + 1
+        );
+        self.run_recovery_stage(stage).await;
+
+        self.network_open_confirmed = false;
+        self.modem_ready = false;
     }
 
     pub async fn disconnect(&mut self) -> Result<(), GsmError> {
@@ -431,12 +528,11 @@ impl GsmModem {
         }
 
         info!("GSM HTTP step: HTTPREAD");
-        if let Ok(body) =
-            send_raw_read_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(
-                &mut self.client,
-                "AT+HTTPREAD=0,512",
-            )
-            .await
+        if let Ok(body) = send_raw_read_cmd::<BUF_SIZE, DEFAULT_RAW_CMD_TIMEOUT_MS>(
+            &mut self.client,
+            "AT+HTTPREAD=0,512",
+        )
+        .await
         {
             info!("HTTPREAD body: {}", body);
         }

--- a/trailsense-edge/src/network/uploader.rs
+++ b/trailsense-edge/src/network/uploader.rs
@@ -32,22 +32,28 @@ pub async fn uploader_task(
         3,
     >,
 ) {
-    #[cfg(feature = "uplink-gsm")]
-    const SEND_TIMEOUT: Duration = Duration::from_secs(90);
     #[cfg(not(feature = "uplink-gsm"))]
     const SEND_TIMEOUT: Duration = Duration::from_secs(30);
-    const RETRY_DELAY: Duration = Duration::from_millis(500);
-    // TODO(recovery): track consecutive GSM failures and trigger modem reset/rebootstrap after N failures instead of immediate terminal behavior (hardware reset).
-    #[cfg(feature = "uplink-gsm")]
-    const SEND_ATTEMPTS: u8 = 1;
     #[cfg(not(feature = "uplink-gsm"))]
     const SEND_ATTEMPTS: u8 = 5;
-    #[cfg(feature = "uplink-gsm")]
-    const GSM_RECOVERY_DELAY: Duration = Duration::from_secs(15);
 
+    // TODO(recovery): track consecutive GSM failures and trigger modem reset/rebootstrap after N failures instead of immediate terminal behavior (hardware reset).
+    #[cfg(feature = "uplink-gsm")]
+    const SEND_TIMEOUT: Duration = Duration::from_secs(45);
+    #[cfg(feature = "uplink-gsm")]
+    const SEND_ATTEMPTS: u8 = 2;
+    #[cfg(feature = "uplink-gsm")]
+    const GSM_RECOVERY_DELAY: Duration = Duration::from_secs(5);
+    #[cfg(feature = "uplink-gsm")]
+    const GSM_MAX_ERRORS: u8 = 5;
+    #[cfg(feature = "uplink-gsm")]
+    let mut consecutive_gsm_failures: u8 = 0;
+
+    const RETRY_DELAY: Duration = Duration::from_millis(500);
     loop {
         let command = network_command_receiver.receive().await;
         let outcome;
+
         match command {
             SystemCmd::SetTransportEnabled { id, enabled } => {
                 if enabled {
@@ -139,7 +145,9 @@ pub async fn uploader_task(
                             info!("UPL: id={} backoff required; recovery pending", id.0);
                             break;
                         }
-                        Err(_) => error!("Package sending timed out"),
+                        Err(_) => {
+                            error!("Package sending timed out");
+                        }
                     }
 
                     if attempt + 1 < SEND_ATTEMPTS {
@@ -147,14 +155,25 @@ pub async fn uploader_task(
                     }
                 }
 
+                #[cfg(feature = "uplink-gsm")]
+                {
+                    if ok {
+                        consecutive_gsm_failures = 0;
+                    } else {
+                        consecutive_gsm_failures = consecutive_gsm_failures.saturating_add(1);
+
+                        if consecutive_gsm_failures >= GSM_MAX_ERRORS {
+                            error!("UPL: reached GSM failure threshold; trigger recovery");
+                            // TODO: trigger recovery/reset event
+                        }
+
+                        Timer::after(GSM_RECOVERY_DELAY).await;
+                    }
+                }
+
                 let event = if ok {
                     UploadEvents::UploadSuccessful
                 } else {
-                    #[cfg(feature = "uplink-gsm")]
-                    {
-                        // Avoid immediately hammering modem HTTP state after failure.
-                        Timer::after(GSM_RECOVERY_DELAY).await;
-                    }
                     UploadEvents::UploadError
                 };
 

--- a/trailsense-edge/src/network/uploader.rs
+++ b/trailsense-edge/src/network/uploader.rs
@@ -7,9 +7,11 @@ use crate::{
     },
     orchestration::types::{DataEvents, SystemCmd, SystemEvents, TransportEvents, UploadEvents},
 };
+
 use embassy_sync::{
     blocking_mutex::raw::CriticalSectionRawMutex, channel::Receiver, pubsub::Publisher,
 };
+
 use embassy_time::{Duration, Timer, WithTimeout};
 use log::{error, info};
 
@@ -37,17 +39,10 @@ pub async fn uploader_task(
     #[cfg(not(feature = "uplink-gsm"))]
     const SEND_ATTEMPTS: u8 = 5;
 
-    // TODO(recovery): track consecutive GSM failures and trigger modem reset/rebootstrap after N failures instead of immediate terminal behavior (hardware reset).
     #[cfg(feature = "uplink-gsm")]
     const SEND_TIMEOUT: Duration = Duration::from_secs(45);
     #[cfg(feature = "uplink-gsm")]
     const SEND_ATTEMPTS: u8 = 2;
-    #[cfg(feature = "uplink-gsm")]
-    const GSM_RECOVERY_DELAY: Duration = Duration::from_secs(5);
-    #[cfg(feature = "uplink-gsm")]
-    const GSM_MAX_ERRORS: u8 = 5;
-    #[cfg(feature = "uplink-gsm")]
-    let mut consecutive_gsm_failures: u8 = 0;
 
     const RETRY_DELAY: Duration = Duration::from_millis(500);
     loop {
@@ -152,22 +147,6 @@ pub async fn uploader_task(
 
                     if attempt + 1 < SEND_ATTEMPTS {
                         Timer::after(RETRY_DELAY).await;
-                    }
-                }
-
-                #[cfg(feature = "uplink-gsm")]
-                {
-                    if ok {
-                        consecutive_gsm_failures = 0;
-                    } else {
-                        consecutive_gsm_failures = consecutive_gsm_failures.saturating_add(1);
-
-                        if consecutive_gsm_failures >= GSM_MAX_ERRORS {
-                            error!("UPL: reached GSM failure threshold; trigger recovery");
-                            // TODO: trigger recovery/reset event
-                        }
-
-                        Timer::after(GSM_RECOVERY_DELAY).await;
                     }
                 }
 

--- a/trailsense-edge/src/orchestration/orchestrator.rs
+++ b/trailsense-edge/src/orchestration/orchestrator.rs
@@ -16,11 +16,11 @@ const PERIOD: Duration = Duration::from_secs(20); // Change for testing reasons.
 const NETWORK_LIMIT: u8 = 5;
 const MAX_LOCAL_SAVES: u8 = 10;
 const MAX_SAVE_FAILURES: u8 = 5;
-const GENERAL_TIMEOUT: Duration = Duration::from_secs(8);
-const CONNECT_TIMEOUT: Duration = Duration::from_secs(20);
-const STOP_SNIFF_TIMEOUT: Duration = Duration::from_secs(8);
-// Must exceed uploader SEND_TIMEOUT (GSM is 90s) to avoid overlapping retries.
-const UPLOAD_TIMEOUT: Duration = Duration::from_secs(120);
+// Keep orchestration waits above GSM worst-case paths (connect/readiness ~= <90s, upload window ~= <100s with current retries).
+const GENERAL_TIMEOUT: Duration = Duration::from_secs(15);
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(90);
+const STOP_SNIFF_TIMEOUT: Duration = Duration::from_secs(10);
+const UPLOAD_TIMEOUT: Duration = Duration::from_secs(130);
 
 enum WaitResult<T> {
     Matched(T),
@@ -393,7 +393,6 @@ pub async fn orchestrate_node(
             }
             SystemState::Sleep => {
                 // TODO: Implement real deep sleep. For now just take a X min break.
-
                 // Reset network error count, so that after sleep it can retry connecting.
                 network_error_count = 0;
                 Timer::after(PERIOD).await;

--- a/trailsense-edge/src/packages/package_store.rs
+++ b/trailsense-edge/src/packages/package_store.rs
@@ -40,7 +40,8 @@ pub fn push(count: u32) -> bool {
 
         // Evict oldest buffered package to keep a bounded queue.
         // TODO: think about better solution, chunking, deleting values in between? Drop a few 0 count values?
-        // Thought appeared on 20.02.2026 --> If is 0, do delete it, only if enough other values are around it maybe?ß
+        // Thought appeared on 20.02.2026 --> If is 0, do delete it, only if enough other values are around it maybe?
+        // Thought appeared on 14.04.2026 --> If too many packages (maybe when needing to save locally or something like that) -> Merge two packages from 5 minutes intervals into one of 10 mins. Basically if i have 4 packages i can half them by just making them contain data for 10 minute intervals.
         if packages.is_full() {
             packages.remove(0);
         }


### PR DESCRIPTION
## Summary
Hardens the GSM uplink path for production-like operation by adding bounded readiness checks, staged modem recovery, retry tuning, and cleanup around transport/control behavior. Hardware GPIO reset integration is intentionally deferred to a follow-up ticket.

## Changes

### Main Changes:
- Added GSM modem readiness gating (`AT`, `AT+CPIN?`, `AT+CEREG?`, `AT+CGATT?`) with retries/timeouts before normal connect flow.
- Added staged GSM recovery ladder on repeated failures (`AT+CFUN` cycle, `AT+CRESET`, `AT+CPOWD=1`), with state invalidation and re-readiness on next connect.
- Added failure streak handling/reset logic:
  - Connect streak resets on successful connect paths.
  - Upload streak resets on successful upload and escalates recovery on repeated transient failures.
- Increased GSM upload retry behavior in uploader (`SEND_ATTEMPTS=2` with retry delay).
- Kept GSM as default transport and cleaned feature-gated transport/module wiring.

### Fixes:
- Fixed duplicate symbol/definition issues under mixed feature builds by separating transport factory paths.
- Fixed payload buffer mismatch risk in GSM raw payload handling (preventing panic-prone sizing mismatch behavior).
- Fixed uploader control-event behavior so failed transport control is no longer reported as success.
- Removed/cleaned dead recovery wiring from active runtime path.

>Small note: during review/testing we found the board’s exposed pin behavior does not currently provide a reliable hardware-reset path, so hardware reset was split into a follow-up ticket while software recovery is merged now.